### PR TITLE
Rename capabilities to features in the sdk codebase

### DIFF
--- a/sandbox/parent/index.html
+++ b/sandbox/parent/index.html
@@ -28,7 +28,7 @@
                         id: 'id',
                         name: 'Corporate overlord'
                     },
-                    capabilities: ['dashboard_cog_menu', 'app_routing']
+                    features: ['dashboard_cog_menu', 'app_routing']
                 });
             };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ export enum Host {
     STAGE = 'https://dd.datad0g.com/'
 }
 
-export enum UiAppCapabilityType {
+export enum UiAppFeatureType {
     APP_CONTEXT = 'app_context',
     DASHBOARD_COG_MENU = 'dashboard_cog_menu',
     DASHBOARD_CUSTOM_WIDGET = 'dashboard_custom_widget',

--- a/src/features/featureManager.ts
+++ b/src/features/featureManager.ts
@@ -2,15 +2,15 @@ import type { ChildClient } from '@datadog/framepost';
 
 import type { DDClient } from '../client';
 import {
-    UiAppCapabilityType,
+    UiAppFeatureType,
     UiAppEventToSubscribeType,
     UiAppEventToTriggerType
 } from '../constants';
 import { getLogger, Logger } from '../logger';
 import { AppContext, ClientOptions } from '../types';
 
-export abstract class CapabilityManager {
-    abstract type: UiAppCapabilityType;
+export abstract class FeatureManager {
+    abstract type: UiAppFeatureType;
     abstract eventsToSubscribe: UiAppEventToSubscribeType[];
     abstract eventsToTrigger: UiAppEventToTriggerType[];
 
@@ -30,7 +30,7 @@ export abstract class CapabilityManager {
     }
 
     /**
-     * A place for eventual extensions of the base client methods, specific to a capability
+     * A place for eventual extensions of the base client methods, specific to a feature
      * Example:
      * private getAdditionalClientMethods(): { [name: string]: Function } {
      *   return  {
@@ -41,7 +41,7 @@ export abstract class CapabilityManager {
     abstract getAdditionalClientMethods(): { [name: string]: Function };
 
     /**
-     * Wraps additional methods in a check against the capability type, then applies to provided client object. Do not override
+     * Wraps additional methods in a check against the feature type, then applies to provided client object. Do not override
      */
     applyAdditionalMethods(client: DDClient) {
         const additionalMethods = this.getAdditionalClientMethods();
@@ -56,7 +56,7 @@ export abstract class CapabilityManager {
                     return method(...args);
                 } else {
                     this.logger.error(
-                        `The ${this.type} capability must be enabled to perform this action`
+                        `The ${this.type} feature must be enabled to perform this action`
                     );
                 }
             };
@@ -72,14 +72,14 @@ export abstract class CapabilityManager {
             this.framePostClient.send(eventType, data);
         } else {
             this.logger.error(
-                `The ${this.type} capability must be enabled to trigger events of type ${eventType}.`
+                `The ${this.type} feature must be enabled to trigger events of type ${eventType}.`
             );
         }
     }
 
     async isEnabled(): Promise<boolean> {
-        const { capabilities } = await this.framePostClient.getContext();
+        const { features } = await this.framePostClient.getContext();
 
-        return capabilities.includes(this.type);
+        return features.includes(this.type);
     }
 }

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,15 +1,15 @@
 import {
-    UiAppCapabilityType,
+    UiAppFeatureType,
     UiAppEventToSubscribeType,
     UiAppEventToTriggerType
 } from '../constants';
 
-import { CapabilityManager } from './capabilityManager';
+import { FeatureManager } from './featureManager';
 
-export type { CapabilityManager } from './capabilityManager';
+export type { FeatureManager } from './featureManager';
 
-class DashboardCogMenuManager extends CapabilityManager {
-    type = UiAppCapabilityType.DASHBOARD_COG_MENU;
+class DashboardCogMenuManager extends FeatureManager {
+    type = UiAppFeatureType.DASHBOARD_COG_MENU;
     eventsToSubscribe = [UiAppEventToSubscribeType.DASHBOARD_COG_MENU_CONTEXT];
     eventsToTrigger = [];
 
@@ -18,8 +18,8 @@ class DashboardCogMenuManager extends CapabilityManager {
     }
 }
 
-class AppRoutingManager extends CapabilityManager {
-    type = UiAppCapabilityType.APP_ROUTING;
+class AppRoutingManager extends FeatureManager {
+    type = UiAppFeatureType.APP_ROUTING;
     eventsToSubscribe = [];
     eventsToTrigger = [
         UiAppEventToTriggerType.RELOAD_FRAME,
@@ -31,8 +31,8 @@ class AppRoutingManager extends CapabilityManager {
     }
 }
 
-class DashboardCustomWidgetManager extends CapabilityManager {
-    type = UiAppCapabilityType.DASHBOARD_CUSTOM_WIDGET;
+class DashboardCustomWidgetManager extends FeatureManager {
+    type = UiAppFeatureType.DASHBOARD_CUSTOM_WIDGET;
     eventsToSubscribe = [
         UiAppEventToSubscribeType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
         UiAppEventToSubscribeType.DASHBOARD_TEMPLATE_VAR_CHANGE,
@@ -45,7 +45,7 @@ class DashboardCustomWidgetManager extends CapabilityManager {
     }
 }
 
-export const capabilityManagers = [
+export const featureManagers = [
     DashboardCogMenuManager,
     AppRoutingManager,
     DashboardCustomWidgetManager

--- a/src/test.ts
+++ b/src/test.ts
@@ -3,7 +3,7 @@ import { init } from '.';
 import { DDClient } from './client';
 import {
     UiAppEventToSubscribeType,
-    UiAppCapabilityType,
+    UiAppFeatureType,
     UiAppEventToTriggerType
 } from './constants';
 import { AppContext } from './types';
@@ -16,7 +16,7 @@ const mockContext: AppContext = {
         id: 'id',
         name: 'Corporate overlord'
     },
-    capabilities: [UiAppCapabilityType.DASHBOARD_COG_MENU]
+    features: [UiAppFeatureType.DASHBOARD_COG_MENU]
 };
 
 class MockFramePostChildClient {
@@ -196,7 +196,7 @@ describe('client', () => {
         expect(callback2).not.toBeCalled();
     });
 
-    test('Does not execute suscribed handlers if the app context does not include the relevant capability', async () => {
+    test('Does not execute suscribed handlers if the app context does not include the relevant feature', async () => {
         const callback1 = jest.fn();
         const callback2 = jest.fn();
 
@@ -213,7 +213,7 @@ describe('client', () => {
 
         mockClient.init({
             ...mockContext,
-            capabilities: []
+            features: []
         });
 
         mockClient.mockEvent(
@@ -230,7 +230,7 @@ describe('client', () => {
         expect(callback2).not.toBeCalled();
     });
 
-    test('Logs an error message in debug mode when a subscription handler is not executed because of failed capability check', async () => {
+    test('Logs an error message in debug mode when a subscription handler is not executed because of failed feature check', async () => {
         const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
         const errorSpy = jest
             .spyOn(console, 'error')
@@ -245,7 +245,7 @@ describe('client', () => {
 
         mockClient.init({
             ...mockContext,
-            capabilities: []
+            features: []
         });
 
         mockClient.mockEvent(
@@ -284,14 +284,14 @@ describe('client', () => {
         errorSpy.mockRestore();
     });
 
-    test('Triggers a valid event if the corresponding capablity is enabled ', async () => {
+    test('Triggers a valid event if the corresponding feature is enabled ', async () => {
         const client = new DDClient();
 
         const callback = jest.fn();
         mockClient.init(
             {
                 ...mockContext,
-                capabilities: [UiAppCapabilityType.APP_ROUTING]
+                features: [UiAppFeatureType.APP_ROUTING]
             },
             callback
         );
@@ -307,7 +307,7 @@ describe('client', () => {
         });
     });
 
-    test('Does not trigger an event if the app context does not include the relevant capability and logs an error in debug mode', async () => {
+    test('Does not trigger an event if the app context does not include the relevant feature and logs an error in debug mode', async () => {
         const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
         const errorSpy = jest
             .spyOn(console, 'error')
@@ -319,7 +319,7 @@ describe('client', () => {
         mockClient.init(
             {
                 ...mockContext,
-                capabilities: []
+                features: []
             },
             callback
         );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,4 @@
-import type {
-    UiAppCapabilityType,
-    UiAppEventToSubscribeType
-} from './constants';
+import type { UiAppFeatureType, UiAppEventToSubscribeType } from './constants';
 
 export interface ClientOptions {
     debug?: boolean;
@@ -26,8 +23,8 @@ export interface AppContext {
         id: string;
         name: string;
     };
-    // list of enabled capabilities
-    capabilities: UiAppCapabilityType[];
+    // list of enabled features
+    features: UiAppFeatureType[];
 }
 
 export interface FrameContext {


### PR DESCRIPTION
This PR renames all occurrences of `capability` or `capabilities` to `feature(s)` in the codebase.