### PR TITLE
Add proxy-based API methods

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,107 @@
+import type { ChildClient } from '@datadog/framepost';
+
+import {
+    UiAppRequestType,
+    IFrameApiRequestMethod,
+    IFrameApiRequestErrorType
+} from './constants';
+import type { Logger } from './logger';
+import type {
+    AppContext,
+    IFrameApiRequest,
+    IframeApiRequestOptions
+} from './types';
+
+export class DDAPIClient {
+    private readonly debug: boolean;
+    private readonly framePostClient: ChildClient<AppContext>;
+    private readonly logger: Logger;
+
+    constructor(debug: boolean, logger: Logger, framePostClient: ChildClient) {
+        this.debug = debug;
+        this.logger = logger;
+        this.framePostClient = framePostClient;
+    }
+
+    private async request<Q = any, R = any>(
+        req: IFrameApiRequest<Q>
+    ): Promise<R> {
+        const response = await this.framePostClient.request<
+            IFrameApiRequest<Q>,
+            any
+        >(UiAppRequestType.API_REQUEST, req);
+
+        if (response.isError) {
+            if (response.type === IFrameApiRequestErrorType.FAILED_REQUEST) {
+                throw response.data;
+            }
+
+            throw new Error(response.message);
+        }
+
+        return response as R;
+    }
+
+    async get<R = any>(
+        resource: string,
+        options: IframeApiRequestOptions = {}
+    ): Promise<R> {
+        return this.request({
+            method: IFrameApiRequestMethod.GET,
+            resource,
+            options,
+            body: null
+        });
+    }
+
+    async post<Q = any, R = any>(
+        resource: string,
+        body: Q,
+        options: IframeApiRequestOptions = {}
+    ): Promise<R> {
+        return this.request({
+            method: IFrameApiRequestMethod.POST,
+            resource,
+            options,
+            body: null
+        });
+    }
+
+    async put<Q = any, R = any>(
+        resource: string,
+        body: Q,
+        options: IframeApiRequestOptions = {}
+    ): Promise<R> {
+        return this.request({
+            method: IFrameApiRequestMethod.PUT,
+            resource,
+            options,
+            body: null
+        });
+    }
+
+    async patch<Q = any, R = any>(
+        resource: string,
+        body: Q,
+        options: IframeApiRequestOptions = {}
+    ): Promise<R> {
+        return this.request({
+            method: IFrameApiRequestMethod.PATCH,
+            resource,
+            options,
+            body: null
+        });
+    }
+
+    async delete<R = any>(
+        resource: string,
+        options: IframeApiRequestOptions = {}
+    ): Promise<R> {
+        return this.request({
+            method: IFrameApiRequestMethod.DELETE,
+            resource,
+            options,
+            body: null
+        });
+    }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import { ChildClient } from '@datadog/framepost';
 
+import { DDAPIClient } from './api';
 import {
     Host,
     UiAppFeatureType,
@@ -9,7 +10,12 @@ import {
 import { FeatureManager } from './features/featureManager';
 import { featureManagers } from './features';
 import { getLogger, Logger } from './logger';
-import { AppContext, FrameContext, EventHandler, ClientOptions } from './types';
+import type {
+    AppContext,
+    FrameContext,
+    EventHandler,
+    ClientOptions
+} from './types';
 
 declare const SDK_VERSION: string;
 
@@ -21,9 +27,10 @@ const DEFAULT_OPTIONS = {
 export class DDClient {
     private readonly host: string;
     private readonly debug: boolean;
-    private readonly framePostClient: ChildClient;
+    private readonly framePostClient: ChildClient<AppContext>;
     private readonly logger: Logger;
     private featureManagers: FeatureManager[];
+    api: DDAPIClient;
 
     constructor(options: ClientOptions = {}) {
         this.host = options.host || DEFAULT_OPTIONS.host;
@@ -38,6 +45,12 @@ export class DDClient {
         });
 
         this.logger = getLogger(options);
+
+        this.api = new DDAPIClient(
+            this.debug,
+            this.logger,
+            this.framePostClient
+        );
 
         this.featureManagers = featureManagers.map(
             Manager =>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,3 +21,23 @@ export enum UiAppEventToTriggerType {
     RELOAD_FRAME = 'reload_frame',
     OPEN_URL = 'open_url'
 }
+
+export enum IFrameApiRequestMethod {
+    GET = 'GET',
+    POST = 'POST',
+    PUT = 'PUT',
+    PATCH = 'PATCH',
+    DELETE = 'DELETE'
+}
+
+export enum IFrameApiRequestErrorType {
+    INVALID_SCOPE = 'invalid_scope',
+    INTERNAL_ERROR = 'internal_error',
+    FAILED_REQUEST = 'failed_request'
+}
+
+// "Requests" are distinct from events in that the sdk client expects a response
+// from the frameManager, or vice-versa
+export enum UiAppRequestType {
+    API_REQUEST = 'api_request'
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,9 @@
-import type { UiAppFeatureType, UiAppEventToSubscribeType } from './constants';
+import type {
+    UiAppFeatureType,
+    UiAppEventToSubscribeType,
+    IFrameApiRequestMethod,
+    IFrameApiRequestErrorType
+} from './constants';
 
 export interface ClientOptions {
     debug?: boolean;
@@ -29,4 +34,24 @@ export interface AppContext {
 
 export interface FrameContext {
     sdkVersion: string;
+}
+
+export interface IframeApiRequestOptions {
+    params?: {
+        [key: string]: any;
+    };
+}
+
+export interface IFrameApiRequest<Q> {
+    method: IFrameApiRequestMethod;
+    resource: string;
+    options: IframeApiRequestOptions;
+    body: Q;
+}
+
+export interface IFrameApiRequestError {
+    isError: true;
+    type: IFrameApiRequestErrorType;
+    message: string;
+    data?: any;
 }


### PR DESCRIPTION
# Main work: 

Add api methods:

```
client.api.get('/api/v1/path', { params: {} }).then().catch()
client.api.post('/api/v1/path', data, options)
client.api.put('/api/v1/path', data, options)
client.api.patch('/api/v1/path', data, options)
client.api.delete('/api/v1/path', options)
```

Unrelated updates:
* Pull version from package.json so that it is always in sync
* transpile to es5