### PR TITLE
Named api methods

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -1,0 +1,149 @@
+import {
+    IFrameApiRequestMethod,
+    UiAppRequestType,
+    IFrameApiRequestErrorType
+} from '../constants';
+import { getLogger } from '../logger';
+
+import { DDAPIClient } from './api';
+
+class MockFramepostClient {
+    request: jest.Mock;
+
+    constructor() {
+        this.request = jest.fn(() => ({
+            isError: false
+        }));
+    }
+}
+
+const framepostClient = new MockFramepostClient();
+const apiClient = new DDAPIClient(
+    false,
+    getLogger({ debug: false }),
+    framepostClient as any
+);
+
+afterEach(() => {
+    framepostClient.request = jest.fn(() => ({
+        isError: false
+    }));
+});
+
+describe('api', () => {
+    test('has an HTTP get method', () => {
+        apiClient.get('/test/endpoint', {
+            params: {
+                testparam: 'testy'
+            }
+        });
+
+        expect(framepostClient.request).toBeCalledWith(
+            UiAppRequestType.API_REQUEST,
+            {
+                method: IFrameApiRequestMethod.GET,
+                resource: '/test/endpoint',
+                options: {
+                    params: {
+                        testparam: 'testy'
+                    }
+                },
+                body: null
+            }
+        );
+    });
+
+    test('has an HTTP post method', () => {
+        apiClient.post('/test/endpoint', 'body');
+
+        expect(framepostClient.request).toBeCalledWith(
+            UiAppRequestType.API_REQUEST,
+            {
+                method: IFrameApiRequestMethod.POST,
+                resource: '/test/endpoint',
+                options: {},
+                body: 'body'
+            }
+        );
+    });
+
+    test('has an HTTP put method', () => {
+        apiClient.put('/test/endpoint', 'body');
+
+        expect(framepostClient.request).toBeCalledWith(
+            UiAppRequestType.API_REQUEST,
+            {
+                method: IFrameApiRequestMethod.PUT,
+                resource: '/test/endpoint',
+                options: {},
+                body: 'body'
+            }
+        );
+    });
+
+    test('has an HTTP patch method', () => {
+        apiClient.patch('/test/endpoint', 'body');
+
+        expect(framepostClient.request).toBeCalledWith(
+            UiAppRequestType.API_REQUEST,
+            {
+                method: IFrameApiRequestMethod.PATCH,
+                resource: '/test/endpoint',
+                options: {},
+                body: 'body'
+            }
+        );
+    });
+
+    test('has an HTTP delete method', () => {
+        apiClient.delete('/test/endpoint');
+
+        expect(framepostClient.request).toBeCalledWith(
+            UiAppRequestType.API_REQUEST,
+            {
+                method: IFrameApiRequestMethod.DELETE,
+                resource: '/test/endpoint',
+                options: {},
+                body: null
+            }
+        );
+    });
+
+    test('throws an error containing response.message if request returns with an error signature object', async () => {
+        framepostClient.request = jest.fn(() => ({
+            isError: true,
+            type: IFrameApiRequestErrorType.INTERNAL_ERROR,
+            message: 'Something went wrong'
+        }));
+
+        let error;
+
+        try {
+            await apiClient.get('/test/endpoint');
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.message).toEqual('Something went wrong');
+    });
+
+    test('throws response.data if request returns with an error signature object with type failed_request', async () => {
+        framepostClient.request = jest.fn(() => ({
+            isError: true,
+            type: IFrameApiRequestErrorType.FAILED_REQUEST,
+            data: {
+                testKey: 'testValue'
+            }
+        }));
+
+        let error;
+
+        try {
+            await apiClient.get('/test/endpoint');
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toEqual({ testKey: 'testValue' });
+    });
+});

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -68,7 +68,7 @@ export class DDAPIClient {
             method: IFrameApiRequestMethod.POST,
             resource,
             options,
-            body: null
+            body
         });
     }
 
@@ -81,7 +81,7 @@ export class DDAPIClient {
             method: IFrameApiRequestMethod.PUT,
             resource,
             options,
-            body: null
+            body
         });
     }
 
@@ -94,7 +94,7 @@ export class DDAPIClient {
             method: IFrameApiRequestMethod.PATCH,
             resource,
             options,
-            body: null
+            body
         });
     }
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,15 +4,18 @@ import {
     UiAppRequestType,
     IFrameApiRequestMethod,
     IFrameApiRequestErrorType
-} from './constants';
-import type { Logger } from './logger';
+} from '../constants';
+import type { Logger } from '../logger';
 import type {
     AppContext,
     IFrameApiRequest,
     IframeApiRequestOptions
-} from './types';
+} from '../types';
+
+import { DDAPIV1Client } from './v1';
 
 export class DDAPIClient {
+    readonly v1: DDAPIV1Client;
     private readonly debug: boolean;
     private readonly framePostClient: ChildClient<AppContext>;
     private readonly logger: Logger;
@@ -21,6 +24,8 @@ export class DDAPIClient {
         this.debug = debug;
         this.logger = logger;
         this.framePostClient = framePostClient;
+
+        this.v1 = new DDAPIV1Client(this);
     }
 
     private async request<Q = any, R = any>(

--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -1,0 +1,11 @@
+import type { DDAPIClient } from '../client';
+
+import { DDMetricsAPIClient } from './metrics';
+
+export class DDAPIV1Client {
+    readonly metrics: DDMetricsAPIClient;
+
+    constructor(apiClient: DDAPIClient) {
+        this.metrics = new DDMetricsAPIClient(apiClient);
+    }
+}

--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -1,4 +1,4 @@
-import type { DDAPIClient } from '../client';
+import type { DDAPIClient } from '../api';
 
 import { DDMetricsAPIClient } from './metrics';
 

--- a/src/api/v1/metrics.test.ts
+++ b/src/api/v1/metrics.test.ts
@@ -1,0 +1,66 @@
+import { DDMetricsAPIClient } from './metrics';
+
+class MockAPIClient {
+    get: jest.Mock;
+
+    constructor() {
+        this.get = jest.fn();
+    }
+}
+
+const apiClient = new MockAPIClient();
+const metrics = new DDMetricsAPIClient(apiClient as any);
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('metrics api v1', () => {
+    test('has a getMetaData method', () => {
+        metrics.getMetadata('metric_id');
+
+        expect(apiClient.get).toBeCalledWith('/api/v1/metrics/metric_id');
+    });
+
+    test('has a listActiveMetrics method', () => {
+        metrics.listActiveMetrics({
+            from: 10101010101,
+            host: 'host'
+        });
+
+        expect(apiClient.get).toBeCalledWith('/api/v1/metrics', {
+            params: {
+                from: 10101010101,
+                host: 'host'
+            }
+        });
+    });
+
+    test('has a search method', () => {
+        metrics.search({
+            q: 'query'
+        });
+
+        expect(apiClient.get).toBeCalledWith('/api/v1/search', {
+            params: {
+                q: 'query'
+            }
+        });
+    });
+
+    test('has a timeseries query method', () => {
+        metrics.query({
+            from: 10101010101,
+            to: 10101010101,
+            query: 'query'
+        });
+
+        expect(apiClient.get).toBeCalledWith('/api/v1/query', {
+            params: {
+                from: 10101010101,
+                to: 10101010101,
+                query: 'query'
+            }
+        });
+    });
+});

--- a/src/api/v1/metrics.ts
+++ b/src/api/v1/metrics.ts
@@ -1,0 +1,56 @@
+import type { DDAPIClient } from '../client';
+
+export class DDMetricsAPIClient {
+    private apiClient: DDAPIClient;
+
+    constructor(apiClient: DDAPIClient) {
+        this.apiClient = apiClient;
+    }
+
+    /**
+     * Get metadata about a specific metric
+     * @see https://docs.datadoghq.com/api/v1/metrics/#get-metric-metadata
+     */
+    getMetadata(metricId: string) {
+        return this.apiClient.get(`/api/v1/metrics/${metricId}`);
+    }
+
+    /**
+     * Get the list of actively reporting metrics from a given time until now.
+     * @see https://docs.datadoghq.com/api/v1/metrics/#get-active-metrics-list
+     */
+    listActiveMetrics(params: ListActiveMetricsParams) {
+        return this.apiClient.get('/api/v1/metrics', { params });
+    }
+
+    /**
+     * Search for metrics from the last 24 hours
+     * @see https://docs.datadoghq.com/api/v1/metrics/#search-metrics
+     */
+    search(params: SearchMetricsParams) {
+        return this.apiClient.get('/api/v1/metrics/search', { params });
+    }
+
+    /**
+     * Query timeseries points.
+     * @see https://docs.datadoghq.com/api/v1/metrics/#query-timeseries-points
+     */
+    query(params: QueryTimeseriesParams) {
+        return this.apiClient.get('/api/v1/query', { params });
+    }
+}
+
+export interface ListActiveMetricsParams {
+    from: number;
+    host?: string;
+}
+
+export interface SearchMetricsParams {
+    q: string;
+}
+
+export interface QueryTimeseriesParams {
+    from: number;
+    to: number;
+    query: string;
+}

--- a/src/api/v1/metrics.ts
+++ b/src/api/v1/metrics.ts
@@ -1,4 +1,4 @@
-import type { DDAPIClient } from '../client';
+import type { DDAPIClient } from '../api';
 
 export class DDMetricsAPIClient {
     private apiClient: DDAPIClient;
@@ -28,7 +28,7 @@ export class DDMetricsAPIClient {
      * @see https://docs.datadoghq.com/api/v1/metrics/#search-metrics
      */
     search(params: SearchMetricsParams) {
-        return this.apiClient.get('/api/v1/metrics/search', { params });
+        return this.apiClient.get('/api/v1/search', { params });
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { ChildClient } from '@datadog/framepost';
 
-import { DDAPIClient } from './api';
+import { DDAPIClient } from './api/client';
 import {
     Host,
     UiAppFeatureType,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { ChildClient } from '@datadog/framepost';
 
-import { DDAPIClient } from './api/client';
+import { DDAPIClient } from './api/api';
 import {
     Host,
     UiAppFeatureType,


### PR DESCRIPTION
In addition to the existing generic api methods added in #9, this creates named methods for each of the GET metrics endpoints:

```
client.api.v1.metrics.getMetadata(metricId);
client.api.v1.metrics.listActiveMetrics({ from, host });
client.api.v1.metrics.search({ q: '...' });
client.api.v1.metrics.query({ from, to, query });
```

I also added appropriate unit tests since I neglected those in the last PR