### PR TITLE
Modal + Menu Item refactor

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -59,7 +59,7 @@ export class DDClient {
     /**
      * Returns app context data, after it is sent from the parent
      */
-    async getContext<T = any>(): Promise<Context<T>> {
+    async getContext(): Promise<Context> {
         return this.framePostClient.getContext();
     }
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -4,6 +4,7 @@ import { DDAPIClient } from '../api/api';
 import { Host } from '../constants';
 import { DDEventsClient } from '../events/events';
 import { DDLocationClient } from '../location/location';
+import { DDModalClient } from '../modal/modal';
 import type { Context, FrameContext, ClientOptions } from '../types';
 import { getLogger, Logger } from '../utils/logger';
 
@@ -22,6 +23,7 @@ export class DDClient {
     api: DDAPIClient;
     events: DDEventsClient;
     location: DDLocationClient;
+    modal: DDModalClient;
 
     constructor(options: ClientOptions = {}) {
         this.host = options.host || DEFAULT_OPTIONS.host;
@@ -50,6 +52,12 @@ export class DDClient {
         );
 
         this.location = new DDLocationClient(
+            this.debug,
+            this.logger,
+            this.framePostClient
+        );
+
+        this.modal = new DDModalClient(
             this.debug,
             this.logger,
             this.framePostClient

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,8 @@ export enum Host {
 
 export enum UiAppFeatureType {
     DASHBOARD_COG_MENU = 'dashboard_cog_menu',
-    DASHBOARD_CUSTOM_WIDGET = 'dashboard_custom_widget'
+    DASHBOARD_CUSTOM_WIDGET = 'dashboard_custom_widget',
+    MODALS = 'modals'
 }
 
 export enum UiAppEventType {
@@ -30,7 +31,9 @@ export enum IFrameApiRequestMethod {
 export enum UiAppRequestType {
     API_REQUEST = 'api_request',
     EVENT_BROADCAST = 'event_broadcast',
-    NAVIGATE_TOP = 'navigate_top'
+    NAVIGATE_TOP = 'navigate_top',
+    OPEN_MODAL = 'open_modal',
+    CLOSE_MODAL = 'close_modal'
 }
 
 // These event types are always allowed, regardless of what features have been enabled

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,10 @@ export enum UiAppEventType {
     DASHBOARD_COG_MENU_CLICK = 'dashboard_cog_menu_click',
     DASHBOARD_TIMEFRAME_CHANGE = 'dashboard_timeframe_change',
     DASHBOARD_TEMPLATE_VAR_CHANGE = 'dashboard_template_var_change',
-    DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE = 'dashboard_custom_widget_options_change'
+    DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE = 'dashboard_custom_widget_options_change',
+    MODAL_CLOSE = 'modal_close',
+    MODAL_ACTION = 'modal_action',
+    MODAL_CANCEL = 'modal_cancel'
 }
 
 export enum IFrameApiRequestMethod {
@@ -38,6 +41,5 @@ export enum UiAppRequestType {
 
 // These event types are always allowed, regardless of what features have been enabled
 export const enabledEvents = new Set<UiAppEventType>([
-    UiAppEventType.CUSTOM_EVENT,
-    UiAppEventType.DASHBOARD_COG_MENU_CLICK
+    UiAppEventType.CUSTOM_EVENT
 ]);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,11 +9,11 @@ export enum UiAppFeatureType {
 }
 
 export enum UiAppEventType {
-    DASHBOARD_COG_MENU_CONTEXT = 'dashboard_cog_menu_context',
+    CUSTOM_EVENT = 'custom_event',
+    DASHBOARD_COG_MENU_CLICK = 'dashboard_cog_menu_click',
     DASHBOARD_TIMEFRAME_CHANGE = 'dashboard_timeframe_change',
     DASHBOARD_TEMPLATE_VAR_CHANGE = 'dashboard_template_var_change',
-    DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE = 'dashboard_custom_widget_options_change',
-    CUSTOM_EVENT = 'custom_event'
+    DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE = 'dashboard_custom_widget_options_change'
 }
 
 export enum IFrameApiRequestMethod {
@@ -35,5 +35,6 @@ export enum UiAppRequestType {
 
 // These event types are always allowed, regardless of what features have been enabled
 export const enabledEvents = new Set<UiAppEventType>([
-    UiAppEventType.CUSTOM_EVENT
+    UiAppEventType.CUSTOM_EVENT,
+    UiAppEventType.DASHBOARD_COG_MENU_CLICK
 ]);

--- a/src/events/events.test.ts
+++ b/src/events/events.test.ts
@@ -25,18 +25,15 @@ describe('events.on()', () => {
         const callback1 = jest.fn();
         const callback2 = jest.fn();
 
-        client.on(UiAppEventType.DASHBOARD_COG_MENU_CONTEXT, callback1);
-        client.on(UiAppEventType.DASHBOARD_COG_MENU_CONTEXT, callback2);
+        client.on(UiAppEventType.DASHBOARD_COG_MENU_CLICK, callback1);
+        client.on(UiAppEventType.DASHBOARD_COG_MENU_CLICK, callback2);
 
         mockFramepostClient.init();
 
-        mockFramepostClient.mockEvent(
-            UiAppEventType.DASHBOARD_COG_MENU_CONTEXT,
-            {
-                id: 'dashboardid',
-                shareToken: 'https://www.google.com'
-            }
-        );
+        mockFramepostClient.mockEvent(UiAppEventType.DASHBOARD_COG_MENU_CLICK, {
+            id: 'dashboardid',
+            shareToken: 'https://www.google.com'
+        });
 
         await flushPromises();
 
@@ -55,9 +52,9 @@ describe('events.on()', () => {
         const callback1 = jest.fn();
         const callback2 = jest.fn();
 
-        client.on(UiAppEventType.DASHBOARD_COG_MENU_CONTEXT, callback1);
+        client.on(UiAppEventType.DASHBOARD_COG_MENU_CLICK, callback1);
         const unsubscribe = client.on(
-            UiAppEventType.DASHBOARD_COG_MENU_CONTEXT,
+            UiAppEventType.DASHBOARD_COG_MENU_CLICK,
             callback2
         );
 
@@ -65,13 +62,10 @@ describe('events.on()', () => {
 
         mockFramepostClient.init();
 
-        mockFramepostClient.mockEvent(
-            UiAppEventType.DASHBOARD_COG_MENU_CONTEXT,
-            {
-                id: 'dashboardid',
-                shareToken: 'https://www.google.com'
-            }
-        );
+        mockFramepostClient.mockEvent(UiAppEventType.DASHBOARD_COG_MENU_CLICK, {
+            id: 'dashboardid',
+            shareToken: 'https://www.google.com'
+        });
 
         await flushPromises();
 
@@ -85,23 +79,23 @@ describe('events.on()', () => {
             .spyOn(console, 'error')
             .mockImplementation(() => {});
 
-        client.on(UiAppEventType.DASHBOARD_COG_MENU_CONTEXT, () => {});
+        client.on(
+            UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
+            () => {}
+        );
 
         mockFramepostClient.init({
             ...mockContext,
-            appContext: {
-                ...mockContext.appContext,
+            app: {
+                ...mockContext.app,
                 features: []
             }
         });
 
-        mockFramepostClient.mockEvent(
-            UiAppEventType.DASHBOARD_COG_MENU_CONTEXT,
-            {
-                id: 'dashboardid',
-                shareToken: 'https://www.google.com'
-            }
-        );
+        mockFramepostClient.mockEvent(UiAppEventType.DASHBOARD_COG_MENU_CLICK, {
+            id: 'dashboardid',
+            shareToken: 'https://www.google.com'
+        });
 
         await flushPromises();
 

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,9 +1,32 @@
 import type { ChildClient } from '@datadog/framepost';
 
 import { UiAppEventType, UiAppRequestType } from '../constants';
-import type { Context, EventHandler } from '../types';
+import type { ModalDefinition } from '../modal/modal';
+import type {
+    Context,
+    EventHandler,
+    FeatureContext,
+    Timeframe,
+    TemplateVariableValue
+} from '../types';
 import type { Logger } from '../utils/logger';
 import { isEventEnabled } from '../utils/utils';
+
+// This interface mapping provides types for event handlers subscribed to with `client.events.on`
+interface DDEventDataTypes {
+    [UiAppEventType.CUSTOM_EVENT]: CustomEventPayload<any>;
+    [UiAppEventType.DASHBOARD_COG_MENU_CLICK]: Required<
+        Pick<FeatureContext, 'dashboard' | 'menuItem'>
+    >;
+    [UiAppEventType.MODAL_CLOSE]: ModalDefinition;
+    [UiAppEventType.MODAL_CANCEL]: ModalDefinition;
+    [UiAppEventType.MODAL_ACTION]: ModalDefinition;
+    [UiAppEventType.DASHBOARD_TIMEFRAME_CHANGE]: Timeframe;
+    [UiAppEventType.DASHBOARD_TEMPLATE_VAR_CHANGE]: TemplateVariableValue[];
+    [UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE]: {
+        [key: string]: any;
+    };
+}
 
 export class DDEventsClient {
     private readonly debug: boolean;
@@ -21,9 +44,9 @@ export class DDEventsClient {
      * method. This method can be called before handshake is successful, but handlers will not execute until
      * after. Will print an error if the installed app does not have the required features to handle the event type.
      */
-    on<T = any>(
-        eventType: UiAppEventType,
-        handler: EventHandler<T>
+    on<K extends keyof DDEventDataTypes>(
+        eventType: K,
+        handler: EventHandler<DDEventDataTypes[K]>
     ): () => void {
         // first, immediately subscribe
         const unsubscribe = this.framePostClient.on(eventType, handler);

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -36,7 +36,7 @@ export class DDEventsClient {
             .then(context => {
                 const canHandleEvent = isEventEnabled(
                     eventType,
-                    context.appContext.features
+                    context.app.features
                 );
 
                 if (!canHandleEvent) {

--- a/src/features/dashboard-cog-menu.ts
+++ b/src/features/dashboard-cog-menu.ts
@@ -3,5 +3,5 @@ import { UiAppFeature } from '../types';
 
 export const dashboardCogMenu: UiAppFeature = {
     type: UiAppFeatureType.DASHBOARD_COG_MENU,
-    events: [UiAppEventType.DASHBOARD_COG_MENU_CONTEXT]
+    events: [UiAppEventType.DASHBOARD_COG_MENU_CLICK]
 };

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,4 +1,5 @@
 import { dashboardCogMenu } from './dashboard-cog-menu';
 import { dashboardCustomWidget } from './dashboard-custom-widget';
+import { modals } from './modals';
 
-export const features = [dashboardCogMenu, dashboardCustomWidget];
+export const features = [dashboardCogMenu, dashboardCustomWidget, modals];

--- a/src/features/modals.ts
+++ b/src/features/modals.ts
@@ -1,0 +1,11 @@
+import { UiAppFeatureType, UiAppEventType } from '../constants';
+import { UiAppFeature } from '../types';
+
+export const modals: UiAppFeature = {
+    type: UiAppFeatureType.MODALS,
+    events: [
+        UiAppEventType.MODAL_CLOSE,
+        UiAppEventType.MODAL_CANCEL,
+        UiAppEventType.MODAL_ACTION
+    ]
+};

--- a/src/modal/modal.test.ts
+++ b/src/modal/modal.test.ts
@@ -42,28 +42,44 @@ describe('modal.open()', () => {
         });
     });
 
-    test('logs an error and does not send request if app does not have modals feature enabled', async () => {
-        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-        const errorSpy = jest
-            .spyOn(console, 'error')
-            .mockImplementation(() => {});
-
-        const requestMock = jest
-            .spyOn(mockFramepostClient, 'request')
-            .mockImplementation(() => null);
-
-        mockFramepostClient.init();
-
-        await client.open({
-            key: 'my-modal',
-            source: 'https://domain.com/modal.html'
+    test('throws an error if app does not have modals feature enabled', async () => {
+        mockFramepostClient.init({
+            ...mockContext,
+            app: {
+                ...mockContext.app,
+                features: [UiAppFeatureType.MODALS]
+            }
         });
 
-        expect(errorSpy).toHaveBeenCalled();
-        expect(requestMock).not.toHaveBeenCalled();
+        let error;
 
-        logSpy.mockRestore();
-        errorSpy.mockRestore();
+        try {
+            // @ts-ignore
+            await client.open({
+                source: 'https://domain.com/modal.html'
+            });
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBeInstanceOf(Error);
+    });
+
+    test('throws an error if modal definition is invalid', async () => {
+        mockFramepostClient.init();
+
+        let error;
+
+        try {
+            await client.open({
+                key: 'my-modal',
+                source: 'https://domain.com/modal.html'
+            });
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBeInstanceOf(Error);
     });
 });
 
@@ -90,24 +106,17 @@ describe('modal.close()', () => {
         );
     });
 
-    test('logs an error and does not send request if app does not have modals feature enabled', async () => {
-        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-        const errorSpy = jest
-            .spyOn(console, 'error')
-            .mockImplementation(() => {});
-
-        const requestMock = jest
-            .spyOn(mockFramepostClient, 'request')
-            .mockImplementation(() => null);
-
+    test('Throws an error if the app does not have the modals feature enabled', async () => {
         mockFramepostClient.init();
 
-        await client.close('my-modal');
+        let error;
 
-        expect(errorSpy).toHaveBeenCalled();
-        expect(requestMock).not.toHaveBeenCalled();
+        try {
+            await client.close('my-modal');
+        } catch (e) {
+            error = e;
+        }
 
-        logSpy.mockRestore();
-        errorSpy.mockRestore();
+        expect(error).toBeInstanceOf(Error);
     });
 });

--- a/src/modal/modal.test.ts
+++ b/src/modal/modal.test.ts
@@ -1,0 +1,113 @@
+import { UiAppFeatureType, UiAppRequestType } from '../constants';
+import { getLogger } from '../utils/logger';
+import { MockFramePostChildClient, mockContext } from '../utils/testUtils';
+
+import { DDModalClient } from './modal';
+
+let mockFramepostClient: MockFramePostChildClient;
+let client: DDModalClient;
+
+beforeEach(() => {
+    mockFramepostClient = new MockFramePostChildClient();
+    client = new DDModalClient(
+        true,
+        getLogger({ debug: true }),
+        mockFramepostClient as any
+    );
+});
+
+describe('modal.open()', () => {
+    test('sends an open modal request to parent', async () => {
+        mockFramepostClient.init({
+            ...mockContext,
+            app: {
+                ...mockContext.app,
+                features: [UiAppFeatureType.MODALS]
+            }
+        });
+        const requestMock = jest
+            .spyOn(mockFramepostClient, 'request')
+            .mockImplementation(() => null);
+
+        const response = await client.open({
+            key: 'my-modal',
+            source: 'https://domain.com/modal.html'
+        });
+
+        expect(response).toEqual(null);
+
+        expect(requestMock).toHaveBeenCalledWith(UiAppRequestType.OPEN_MODAL, {
+            key: 'my-modal',
+            source: 'https://domain.com/modal.html'
+        });
+    });
+
+    test('logs an error and does not send request if app does not have modals feature enabled', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const errorSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        const requestMock = jest
+            .spyOn(mockFramepostClient, 'request')
+            .mockImplementation(() => null);
+
+        mockFramepostClient.init();
+
+        await client.open({
+            key: 'my-modal',
+            source: 'https://domain.com/modal.html'
+        });
+
+        expect(errorSpy).toHaveBeenCalled();
+        expect(requestMock).not.toHaveBeenCalled();
+
+        logSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+});
+
+describe('modal.close()', () => {
+    test('sends an close modal request to parent', async () => {
+        mockFramepostClient.init({
+            ...mockContext,
+            app: {
+                ...mockContext.app,
+                features: [UiAppFeatureType.MODALS]
+            }
+        });
+        const requestMock = jest
+            .spyOn(mockFramepostClient, 'request')
+            .mockImplementation(() => null);
+
+        const response = await client.close('my-modal');
+
+        expect(response).toEqual(null);
+
+        expect(requestMock).toHaveBeenCalledWith(
+            UiAppRequestType.CLOSE_MODAL,
+            'my-modal'
+        );
+    });
+
+    test('logs an error and does not send request if app does not have modals feature enabled', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const errorSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        const requestMock = jest
+            .spyOn(mockFramepostClient, 'request')
+            .mockImplementation(() => null);
+
+        mockFramepostClient.init();
+
+        await client.close('my-modal');
+
+        expect(errorSpy).toHaveBeenCalled();
+        expect(requestMock).not.toHaveBeenCalled();
+
+        logSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+});

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -1,0 +1,90 @@
+import type { ChildClient } from '@datadog/framepost';
+
+import { UiAppFeatureType, UiAppRequestType } from '../constants';
+import type { Context } from '../types';
+import type { Logger } from '../utils/logger';
+import { isFeatureEnabled } from '../utils/utils';
+
+export class DDModalClient {
+    private readonly debug: boolean;
+    private readonly logger: Logger;
+    private readonly framePostClient: ChildClient<Context>;
+
+    constructor(debug: boolean, logger: Logger, framePostClient: ChildClient) {
+        this.debug = debug;
+        this.logger = logger;
+        this.framePostClient = framePostClient;
+    }
+
+    /**
+     * Opens a modal, given a full modal definition or the key of a modal
+     * definition pre-defined in the app manifest
+     */
+    async open(definitionOrKey: ModalDefinition | string) {
+        const isEnabled = await this.isEnabled();
+
+        if (isEnabled) {
+            return this.framePostClient.request(
+                UiAppRequestType.OPEN_MODAL,
+                definitionOrKey
+            );
+        } else {
+            this.logger.error(
+                `Please enable the "${UiAppFeatureType.MODALS}" feature to access this functionality.`
+            );
+        }
+    }
+
+    /**
+     * Closes any active modals opened by this app. If a key is provided, it will only close the modal
+     * if it matches the provided key.
+     */
+    async close(key?: string) {
+        const isEnabled = await this.isEnabled();
+
+        if (isEnabled) {
+            return this.framePostClient.request(
+                UiAppRequestType.CLOSE_MODAL,
+                key
+            );
+        } else {
+            this.logger.error(
+                `Please enable the "${UiAppFeatureType.MODALS}" feature to access this functionality.`
+            );
+        }
+    }
+
+    private async isEnabled() {
+        const {
+            app: { features }
+        } = await this.framePostClient.getContext();
+
+        return isFeatureEnabled(UiAppFeatureType.MODALS, features);
+    }
+}
+
+export enum ModalSize {
+    SMALL = 'sm',
+    MEDIUM = 'md',
+    LARGE = 'lg'
+    // TODO: implement auto-sized modals
+}
+
+export enum ModalActionLevel {
+    PRIMARY = 'primary',
+    SUCCESS = 'success',
+    WARNING = 'warning',
+    DANGER = 'danger'
+}
+
+export interface ModalDefinition {
+    key: string;
+    title?: string;
+    size?: ModalSize;
+    isCloseable?: boolean;
+    message?: string;
+    source?: string;
+    actionLabel?: string;
+    actionLevel?: ModalActionLevel;
+    cancelLabel?: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,11 +58,16 @@ export interface DashboardContext {
     templateVars: TemplateVariableValue[];
 }
 
+// TODO: This is an incomplete typing because widget API typing is exenstive and varied based on widget type.
+// We should port full typing here eventually
 export interface DashboardWidgetContext {
-    // probably need more here
-    options: {
-        [key: string]: any;
+    id?: number;
+    definition: {
+        options?: {
+            [key: string]: any;
+        };
     };
+    layout?: any;
 }
 
 export interface MenuItemContext {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,16 +43,18 @@ export interface TemplateVariableValue {
     default?: string;
 }
 
+export interface Timeframe {
+    from_ts: number;
+    to_ts: number;
+    live: boolean;
+}
+
 export interface DashboardContext {
     // dashboard id
     id: string;
     // public dashboard share token
     shareToken: string;
-    timeframe: {
-        from_ts: number;
-        to_ts: number;
-        live: boolean;
-    };
+    timeframe: Timeframe;
     templateVars: TemplateVariableValue[];
 }
 
@@ -78,6 +80,7 @@ export interface FeatureContext {
 export interface Context extends FeatureContext {
     app: AppContext;
 }
+
 export interface FrameContext {
     sdkVersion: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,24 +43,41 @@ export interface TemplateVariableValue {
     default?: string;
 }
 
-export interface CustomWidgetFrameContext {
+export interface DashboardContext {
+    // dashboard id
+    id: string;
+    // public dashboard share token
+    shareToken: string;
     timeframe: {
         from_ts: number;
         to_ts: number;
         live: boolean;
     };
     templateVars: TemplateVariableValue[];
+}
+
+export interface DashboardWidgetContext {
+    // probably need more here
     options: {
         [key: string]: any;
     };
 }
 
-// Context is the data type that gets sent to the `init` method
-export interface Context<T = any> {
-    appContext: AppContext;
-    frameContext: T;
+export interface MenuItemContext {
+    key: string;
 }
 
+// A combined object specifing data about the context of a feature within the app
+export interface FeatureContext {
+    dashboard?: DashboardContext;
+    widget?: DashboardWidgetContext;
+    menuItem?: MenuItemContext;
+}
+
+// A full context object including above feature context and additional global app context
+export interface Context extends FeatureContext {
+    app: AppContext;
+}
 export interface FrameContext {
     sdkVersion: string;
 }

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -35,7 +35,7 @@ export const uniqueInt = (): number => {
 };
 
 export const mockContext: Context = {
-    appContext: {
+    app: {
         currentUser: {
             id: 45678,
             name: 'User',
@@ -46,8 +46,7 @@ export const mockContext: Context = {
             name: 'Corporate overlord'
         },
         features: [UiAppFeatureType.DASHBOARD_COG_MENU]
-    },
-    frameContext: null
+    }
 };
 
 export class MockFramePostChildClient {


### PR DESCRIPTION
* **Breaking**: Refactors `context` typing to include standardized location-specific data
* * **Breaking**: Replaces `DASHBOARD_COG_MENU_CONTEXT` with `DASHBOARD_COG_MENU_CLICK` event
* Adds `client.modal.open()` and `client.modal.close()` hooks for opening modals from the SDK. Developers may provide a full modal definition, or a string key referencing a definition provided in the app manifest.
* Adds `modal` feature with three new events, for modal closing (clicking outside or the "x"), cancelling, or clicking the main action button
* Provides strong typing for event handlers subscribed with `client.events.on()`