### PR TITLE
Add optional context for side panel

### DIFF
--- a/src/side-panel/side-panel.test.ts
+++ b/src/side-panel/side-panel.test.ts
@@ -91,7 +91,7 @@ describe('sidePanel.open()', () => {
             UiAppRequestType.OPEN_SIDE_PANEL,
             {
                 definitionOrKey: 'my-panel',
-                context: { foo: 'baar' }
+                args: { foo: 'baar' }
             }
         );
     });
@@ -125,7 +125,7 @@ describe('sidePanel.open()', () => {
                     key: 'my-panel',
                     source: 'panel.html'
                 },
-                context: { foo: 'baar' }
+                args: { foo: 'baar' }
             }
         );
     });

--- a/src/side-panel/side-panel.test.ts
+++ b/src/side-panel/side-panel.test.ts
@@ -71,6 +71,65 @@ describe('sidePanel.open()', () => {
         );
     });
 
+    test('sends an open request with key and context to parent', async () => {
+        mockFramepostClient.init({
+            ...mockContext,
+            app: {
+                ...mockContext.app,
+                features: [UiAppFeatureType.SIDE_PANELS]
+            }
+        });
+        const requestMock = jest
+            .spyOn(mockFramepostClient, 'request')
+            .mockImplementation(() => null);
+
+        const response = await client.open('my-panel', { foo: 'baar' });
+
+        expect(response).toEqual(null);
+
+        expect(requestMock).toHaveBeenCalledWith(
+            UiAppRequestType.OPEN_SIDE_PANEL,
+            {
+                definitionOrKey: 'my-panel',
+                context: { foo: 'baar' }
+            }
+        );
+    });
+
+    test('sends an open request with definition and context to parent', async () => {
+        mockFramepostClient.init({
+            ...mockContext,
+            app: {
+                ...mockContext.app,
+                features: [UiAppFeatureType.SIDE_PANELS]
+            }
+        });
+        const requestMock = jest
+            .spyOn(mockFramepostClient, 'request')
+            .mockImplementation(() => null);
+
+        const response = await client.open(
+            {
+                key: 'my-panel',
+                source: 'panel.html'
+            },
+            { foo: 'baar' }
+        );
+
+        expect(response).toEqual(null);
+
+        expect(requestMock).toHaveBeenCalledWith(
+            UiAppRequestType.OPEN_SIDE_PANEL,
+            {
+                definitionOrKey: {
+                    key: 'my-panel',
+                    source: 'panel.html'
+                },
+                context: { foo: 'baar' }
+            }
+        );
+    });
+
     test('throws an error if definition is invalid', async () => {
         mockFramepostClient.init({
             ...mockContext,

--- a/src/side-panel/side-panel.test.ts
+++ b/src/side-panel/side-panel.test.ts
@@ -39,8 +39,10 @@ describe('sidePanel.open()', () => {
         expect(requestMock).toHaveBeenCalledWith(
             UiAppRequestType.OPEN_SIDE_PANEL,
             {
-                key: 'my-panel',
-                source: 'panel.html'
+                definitionOrKey: {
+                    key: 'my-panel',
+                    source: 'panel.html'
+                }
             }
         );
     });
@@ -63,7 +65,9 @@ describe('sidePanel.open()', () => {
 
         expect(requestMock).toHaveBeenCalledWith(
             UiAppRequestType.OPEN_SIDE_PANEL,
-            'my-panel'
+            {
+                definitionOrKey: 'my-panel'
+            }
         );
     });
 

--- a/src/side-panel/side-panel.ts
+++ b/src/side-panel/side-panel.ts
@@ -15,13 +15,13 @@ export class DDSidePanelClient extends DDFeatureClient {
      * Opens a side panel, given a full side panel definition or the key of a side panel
      * definition pre-defined in the app manifest
      */
-    async open(definitionOrKey: SidePanelDefinition | string, context?: any) {
+    async open(definitionOrKey: SidePanelDefinition | string, args?: any) {
         await this.validateFeatureIsEnabled();
 
         if (validateKey(definitionOrKey)) {
             return this.framePostClient.request(
                 UiAppRequestType.OPEN_SIDE_PANEL,
-                { definitionOrKey, context }
+                { definitionOrKey, args }
             );
         }
     }

--- a/src/side-panel/side-panel.ts
+++ b/src/side-panel/side-panel.ts
@@ -15,13 +15,13 @@ export class DDSidePanelClient extends DDFeatureClient {
      * Opens a side panel, given a full side panel definition or the key of a side panel
      * definition pre-defined in the app manifest
      */
-    async open(definitionOrKey: SidePanelDefinition | string) {
+    async open(definitionOrKey: SidePanelDefinition | string, context?: any) {
         await this.validateFeatureIsEnabled();
 
         if (validateKey(definitionOrKey)) {
             return this.framePostClient.request(
                 UiAppRequestType.OPEN_SIDE_PANEL,
-                definitionOrKey
+                { definitionOrKey, context }
             );
         }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,17 +75,14 @@ export interface DashboardWidgetContext {
 export interface MenuItemContext {
     key: string;
 }
-// Generic type of optional arguements passed to different feature components like modal, sidepanel, etc
-export interface CustomFeatureContext {
-    [key: string]: any;
-}
 
 // A combined object specifing data about the context of a feature within the app
 export interface FeatureContext {
     dashboard?: DashboardContext;
     widget?: DashboardWidgetContext;
     menuItem?: MenuItemContext;
-    sidePanel?: CustomFeatureContext;
+    // Optional arguements passed to different feature components like modal, side panel, etc
+    args?: any;
 }
 
 // A full context object including above feature context and additional global app context

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,12 +75,17 @@ export interface DashboardWidgetContext {
 export interface MenuItemContext {
     key: string;
 }
+// Generic type of optional arguements passed to different feature components like modal, sidepanel, etc
+export interface CustomFeatureContext {
+    [key: string]: any;
+}
 
 // A combined object specifing data about the context of a feature within the app
 export interface FeatureContext {
     dashboard?: DashboardContext;
     widget?: DashboardWidgetContext;
     menuItem?: MenuItemContext;
+    sidePanel?: CustomFeatureContext;
 }
 
 // A full context object including above feature context and additional global app context


### PR DESCRIPTION
Support an optional second argument for `client.sidePanel.open()` which is a custom context than can be passed from the sdk.