### PR TITLE
Add DASHBOARD_CURSOR_CHANGE event

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export enum UiAppEventType {
     DASHBOARD_COG_MENU_CLICK = 'dashboard_cog_menu_click',
     DASHBOARD_CONTEXT_MENU_CLICK = 'dashboard_context_menu_click',
     DASHBOARD_TIMEFRAME_CHANGE = 'dashboard_timeframe_change',
+    DASHBOARD_CURSOR_CHANGE = 'dashboard_cursor_change',
     DASHBOARD_TEMPLATE_VAR_CHANGE = 'dashboard_template_var_change',
     DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE = 'dashboard_custom_widget_options_change',
 

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -25,6 +25,7 @@ interface DDEventDataTypes {
         Pick<FeatureContext, 'dashboard' | 'widget' | 'menuItem'>
     >;
     [UiAppEventType.DASHBOARD_TIMEFRAME_CHANGE]: Timeframe;
+    [UiAppEventType.DASHBOARD_CURSOR_CHANGE]: number | null;
     [UiAppEventType.DASHBOARD_TEMPLATE_VAR_CHANGE]: TemplateVariableValue[];
     [UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE]: {
         [key: string]: any;

--- a/src/features/dashboard-custom-widget.ts
+++ b/src/features/dashboard-custom-widget.ts
@@ -6,6 +6,7 @@ export const dashboardCustomWidget: UiAppFeature = {
     events: [
         UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
         UiAppEventType.DASHBOARD_TEMPLATE_VAR_CHANGE,
-        UiAppEventType.DASHBOARD_TIMEFRAME_CHANGE
+        UiAppEventType.DASHBOARD_TIMEFRAME_CHANGE,
+        UiAppEventType.DASHBOARD_CURSOR_CHANGE
     ]
 };


### PR DESCRIPTION
![Screen Recording 2021-02-09 at 10 32 26 AM](https://user-images.githubusercontent.com/4038920/107387083-7be90300-6ac2-11eb-9dc4-9359b860d934.gif)


This PR updates the SDK to support the DASHBOARD_CURSOR_CHANGE event, added in https://github.com/DataDog/web-ui/pull/27576

Note that the event will not report the cursor timestamp until https://github.com/DataDog/web-ui/pull/27575/  is merged


### Testing

- hotdog on branch for https://github.com/DataDog/web-ui/pull/27576
- add a custom app (point to localhost:3000)
- [run this app](https://github.com/DataDog/app-dash-cursor-change) on localhost:3000