### PR TITLE
[UI Apps] Private secrets part 2

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,12 +61,13 @@ export enum UiAppRequestType {
     CLOSE_SIDE_PANEL = 'close_side_panel',
 
     // Secrets
-    SAVE_SECRET = 'save_secret',
+    STORE_SECRET = 'store_secret',
     REMOVE_SECRET = 'remove_secret',
-    GET_ALL_SECRETS = 'get_all_secrets',
+    LOAD_ALL_SECRETS = 'load_all_secrets',
     REMOVE_ALL_SECRETS = 'remove_all_secrets',
     LOAD_SECRET = 'load_secret',
-    DECRYPT_SECRET = 'decrypt_secret'
+    GET_SECRET = 'get_secret',
+    SET_SECRET = 'set_secret'
 }
 
 // These event types are always allowed, regardless of what features have been enabled

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,11 +61,11 @@ export enum UiAppRequestType {
     CLOSE_SIDE_PANEL = 'close_side_panel',
 
     // Secrets
-    SET_SECRET = 'set_secret',
+    SAVE_SECRET = 'save_secret',
     REMOVE_SECRET = 'remove_secret',
     GET_ALL_SECRETS = 'get_all_secrets',
     REMOVE_ALL_SECRETS = 'remove_all_secrets',
-    GET_SECRET = 'get_secret',
+    LOAD_SECRET = 'load_secret',
     DECRYPT_SECRET = 'decrypt_secret'
 }
 

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
 });
 
 describe('client.get', () => {
-    it('sends a DECRYPT_SECRET request to the parent with the data to encrypt', async () => {
+    it('sends a GET_SECRET request to the parent with the data to encrypt', async () => {
         mockFramepostClient.init(mockContext);
 
         const requestMock = jest
@@ -32,7 +32,7 @@ describe('client.get', () => {
         const response = await client.get('my-secret-key');
         expect(response).toEqual(null);
         expect(requestMock).toHaveBeenCalledWith(
-            UiAppRequestType.DECRYPT_SECRET,
+            UiAppRequestType.GET_SECRET,
             'my-secret-key'
         );
     });

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -56,11 +56,11 @@ describe('secrets request handlers', () => {
     let getItemMock: jest.SpyInstance;
     let removeItemMock: jest.SpyInstance;
 
-    it('handles SET_SECRET request when sent from the parent frame', () => {
+    it('handles SAVE_STOREET request when sent from the parent frame', () => {
         mockFramepostClient.init();
 
         const result = mockFramepostClient.mockRequest(
-            UiAppRequestType.SET_SECRET,
+            UiAppRequestType.STORE_SECRET,
             {
                 key,
                 secret
@@ -71,12 +71,12 @@ describe('secrets request handlers', () => {
         expect(mockStorage.getItem(key)).toEqual(secret);
     });
 
-    it('handles GET_SECRET request when sent from the parent frame', () => {
+    it('handles LOAD_SECRET request when sent from the parent frame', () => {
         mockFramepostClient.init();
         mockStorage.setItem(key, secret);
 
         const result = mockFramepostClient.mockRequest(
-            UiAppRequestType.GET_SECRET,
+            UiAppRequestType.LOAD_SECRET,
             {
                 key
             }
@@ -86,7 +86,7 @@ describe('secrets request handlers', () => {
         expect(mockStorage.getItem(key)).toEqual(secret);
     });
 
-    it('handles GET_ALL_SECRETS request when sent from the parent frame', () => {
+    it('handles LOAD_ALL_SECRETS request when sent from the parent frame', () => {
         mockFramepostClient.init();
         const prefix = 'my_app_prefix:';
         mockStorage.setItem(`${prefix}key_1`, 'secret_1');
@@ -94,7 +94,7 @@ describe('secrets request handlers', () => {
         mockStorage.setItem('another_key', 'secret_3');
 
         const result = mockFramepostClient.mockRequest(
-            UiAppRequestType.GET_ALL_SECRETS,
+            UiAppRequestType.LOAD_ALL_SECRETS,
             {
                 prefix
             }

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -56,7 +56,7 @@ describe('secrets request handlers', () => {
     let getItemMock: jest.SpyInstance;
     let removeItemMock: jest.SpyInstance;
 
-    it('handles SAVE_STOREET request when sent from the parent frame', () => {
+    it('handles STORE_SECRET request when sent from the parent frame', () => {
         mockFramepostClient.init();
 
         const result = mockFramepostClient.mockRequest(

--- a/src/secrets/secrets.ts
+++ b/src/secrets/secrets.ts
@@ -116,8 +116,11 @@ export class DDSecretsClient {
         return this.framePostClient.request(UiAppRequestType.GET_SECRET, key);
     }
 
-    async set(key: string) {
-        return this.framePostClient.request(UiAppRequestType.GET_SECRET, key);
+    async set(key: string, data: string) {
+        return this.framePostClient.request(UiAppRequestType.SET_SECRET, {
+            key,
+            data
+        });
     }
 }
 

--- a/src/secrets/secrets.ts
+++ b/src/secrets/secrets.ts
@@ -26,18 +26,18 @@ export class DDSecretsClient {
 
     private registerRequestHandlers() {
         this.framePostClient.onRequest(
-            UiAppRequestType.SET_SECRET,
-            this.handleSetSecretRequest.bind(this)
+            UiAppRequestType.STORE_SECRET,
+            this.handleStoreSecretRequest.bind(this)
         );
 
         this.framePostClient.onRequest(
-            UiAppRequestType.GET_SECRET,
-            this.handleGetSecretRequest.bind(this)
+            UiAppRequestType.LOAD_SECRET,
+            this.handleLoadSecretRequest.bind(this)
         );
 
         this.framePostClient.onRequest(
-            UiAppRequestType.GET_ALL_SECRETS,
-            this.handleGetAllSecretsRequest.bind(this)
+            UiAppRequestType.LOAD_ALL_SECRETS,
+            this.handleLoadAllSecretsRequest.bind(this)
         );
 
         this.framePostClient.onRequest(
@@ -51,7 +51,7 @@ export class DDSecretsClient {
         );
     }
 
-    private handleSetSecretRequest({ key, secret }: SetSecretRequest) {
+    private handleStoreSecretRequest({ key, secret }: StoreSecretRequest) {
         try {
             window.localStorage.setItem(key, secret);
             return true;
@@ -61,7 +61,7 @@ export class DDSecretsClient {
         }
     }
 
-    private handleGetSecretRequest({ key }: GetSecretRequest) {
+    private handleLoadSecretRequest({ key }: LoadSecretRequest) {
         try {
             return window.localStorage.getItem(key);
         } catch (error) {
@@ -70,7 +70,7 @@ export class DDSecretsClient {
         }
     }
 
-    private handleGetAllSecretsRequest({ prefix }: GetAllSecretsRequest) {
+    private handleLoadAllSecretsRequest({ prefix }: LoadAllSecretsRequest) {
         try {
             const keys = getLocalStorageKeys().filter(
                 key => key && key.startsWith(prefix)
@@ -111,8 +111,15 @@ export class DDSecretsClient {
         }
     }
 
-    // returns the decrypted secret for a given key
+    // returns a promises that resolves with the decrypted secret for a given key
     async get(key: string) {
+        return this.framePostClient.request(
+            UiAppRequestType.DECRYPT_SECRET,
+            key
+        );
+    }
+
+    async set(key: string) {
         return this.framePostClient.request(
             UiAppRequestType.DECRYPT_SECRET,
             key
@@ -120,19 +127,19 @@ export class DDSecretsClient {
     }
 }
 
-export interface SetSecretRequest {
+export interface StoreSecretRequest {
     key: string;
     secret: string;
 }
 
-export interface GetAllSecretsRequest {
+export interface LoadAllSecretsRequest {
     prefix: string;
 }
 export interface RemoveAllSecretsRequest {
     prefix: string;
 }
 
-export interface GetSecretRequest {
+export interface LoadSecretRequest {
     key: string;
 }
 export interface RemoveSecretRequest {

--- a/src/secrets/secrets.ts
+++ b/src/secrets/secrets.ts
@@ -113,17 +113,11 @@ export class DDSecretsClient {
 
     // returns a promises that resolves with the decrypted secret for a given key
     async get(key: string) {
-        return this.framePostClient.request(
-            UiAppRequestType.DECRYPT_SECRET,
-            key
-        );
+        return this.framePostClient.request(UiAppRequestType.GET_SECRET, key);
     }
 
     async set(key: string) {
-        return this.framePostClient.request(
-            UiAppRequestType.DECRYPT_SECRET,
-            key
-        );
+        return this.framePostClient.request(UiAppRequestType.GET_SECRET, key);
     }
 }
 


### PR DESCRIPTION
- Code refactor and more meaningful request names
- Add better error handling for reading secrets
- Add support for setting secrets using the sdk (`client.secrets.set(key, value)`)