### PR TITLE
Misc. Development experience updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@datadog/framepost": "https://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136"
+        "@datadog/framepost": "0.2.2"
     },
     "devDependencies": {
         "@types/jest": "^26.0.14",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@datadog/framepost": "git://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136"
+        "@datadog/framepost": "https://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136"
     },
     "devDependencies": {
         "@types/jest": "^26.0.14",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@datadog/framepost": "0.2.0"
+        "@datadog/framepost": "git://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136"
     },
     "devDependencies": {
         "@types/jest": "^26.0.14",

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -1,27 +1,16 @@
 import { IFrameApiRequestMethod, UiAppRequestType } from '../constants';
-import { getLogger } from '../utils/logger';
+import { MockClient } from '../utils/testUtils';
 
 import { DDAPIClient } from './api';
 
-class MockFramepostClient {
-    request: jest.Mock;
+let client: MockClient;
+let apiClient: DDAPIClient;
 
-    constructor() {
-        this.request = jest.fn(() => ({
-            isError: false
-        }));
-    }
-}
+beforeEach(() => {
+    client = new MockClient();
+    apiClient = new DDAPIClient(client as any);
 
-const framepostClient = new MockFramepostClient();
-const apiClient = new DDAPIClient(
-    false,
-    getLogger({ debug: false }),
-    framepostClient as any
-);
-
-afterEach(() => {
-    framepostClient.request = jest.fn(() => ({
+    client.framePostClient.request = jest.fn(() => ({
         isError: false
     }));
 });
@@ -34,7 +23,7 @@ describe('api', () => {
             }
         });
 
-        expect(framepostClient.request).toBeCalledWith(
+        expect(client.framePostClient.request).toBeCalledWith(
             UiAppRequestType.API_REQUEST,
             {
                 method: IFrameApiRequestMethod.GET,
@@ -52,7 +41,7 @@ describe('api', () => {
     test('has an HTTP post method', () => {
         apiClient.post('/test/endpoint', 'body');
 
-        expect(framepostClient.request).toBeCalledWith(
+        expect(client.framePostClient.request).toBeCalledWith(
             UiAppRequestType.API_REQUEST,
             {
                 method: IFrameApiRequestMethod.POST,
@@ -66,7 +55,7 @@ describe('api', () => {
     test('has an HTTP put method', () => {
         apiClient.put('/test/endpoint', 'body');
 
-        expect(framepostClient.request).toBeCalledWith(
+        expect(client.framePostClient.request).toBeCalledWith(
             UiAppRequestType.API_REQUEST,
             {
                 method: IFrameApiRequestMethod.PUT,
@@ -80,7 +69,7 @@ describe('api', () => {
     test('has an HTTP patch method', () => {
         apiClient.patch('/test/endpoint', 'body');
 
-        expect(framepostClient.request).toBeCalledWith(
+        expect(client.framePostClient.request).toBeCalledWith(
             UiAppRequestType.API_REQUEST,
             {
                 method: IFrameApiRequestMethod.PATCH,
@@ -94,7 +83,7 @@ describe('api', () => {
     test('has an HTTP delete method', () => {
         apiClient.delete('/test/endpoint');
 
-        expect(framepostClient.request).toBeCalledWith(
+        expect(client.framePostClient.request).toBeCalledWith(
             UiAppRequestType.API_REQUEST,
             {
                 method: IFrameApiRequestMethod.DELETE,
@@ -106,7 +95,7 @@ describe('api', () => {
     });
 
     test('propagates errors from framepost request method', async () => {
-        framepostClient.request = jest.fn(() => {
+        client.framePostClient.request = jest.fn(() => {
             throw new Error('Something went wrong');
         });
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,25 +1,15 @@
-import type { ChildClient } from '@datadog/framepost';
-
+import type { DDClient } from '../client/client';
 import { UiAppRequestType, IFrameApiRequestMethod } from '../constants';
-import type {
-    Context,
-    IFrameApiRequest,
-    IframeApiRequestOptions
-} from '../types';
-import type { Logger } from '../utils/logger';
+import type { IFrameApiRequest, IframeApiRequestOptions } from '../types';
 
 import { DDAPIV1Client } from './v1';
 
 export class DDAPIClient {
     readonly v1: DDAPIV1Client;
-    private readonly debug: boolean;
-    private readonly framePostClient: ChildClient<Context>;
-    private readonly logger: Logger;
+    private readonly client: DDClient;
 
-    constructor(debug: boolean, logger: Logger, framePostClient: ChildClient) {
-        this.debug = debug;
-        this.logger = logger;
-        this.framePostClient = framePostClient;
+    constructor(client: DDClient) {
+        this.client = client;
 
         this.v1 = new DDAPIV1Client(this);
     }
@@ -27,7 +17,7 @@ export class DDAPIClient {
     private async request<Q = any, R = any>(
         req: IFrameApiRequest<Q>
     ): Promise<R> {
-        return this.framePostClient.request<IFrameApiRequest<Q>, R>(
+        return this.client.framePostClient.request<IFrameApiRequest<Q>, R>(
             UiAppRequestType.API_REQUEST,
             req
         );

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -1,30 +1,25 @@
 import { UiAppRequestType } from '../constants';
-import { getLogger } from '../utils/logger';
-import { MockFramePostChildClient, mockContext } from '../utils/testUtils';
+import { MockClient, mockContext } from '../utils/testUtils';
 
 import { DDAuthClient } from './auth';
 
-let mockFramepostClient: MockFramePostChildClient;
-let client: DDAuthClient;
+let client: MockClient;
+let authClient: DDAuthClient;
 
 beforeEach(() => {
-    mockFramepostClient = new MockFramePostChildClient();
-    client = new DDAuthClient(
-        true,
-        getLogger({ debug: true }),
-        mockFramepostClient as any
-    );
+    client = new MockClient();
+    authClient = new DDAuthClient(client as any);
 });
 
 describe('client.requestAuthTokens', () => {
     it('sends a REQUEST_AUTH_TOKENS request to the parent with the auth url', async () => {
-        mockFramepostClient.init(mockContext);
+        client.framePostClient.init(mockContext);
 
         const requestMock = jest
-            .spyOn(mockFramepostClient, 'request')
+            .spyOn(client.framePostClient, 'request')
             .mockImplementation(() => 'a=abc&b=xyz');
 
-        const response = await client.requestAuthTokens(
+        const response = await authClient.requestAuthTokens(
             'https:///auth.com',
             'http://domain.com'
         );
@@ -42,17 +37,17 @@ describe('client.requestAuthTokens', () => {
 
 describe('client.resolveAuthTokens', () => {
     it('responds to REQUEST_AUTH_TOKENS request to the parent with the current URL query params', async () => {
-        mockFramepostClient.init(mockContext);
+        client.framePostClient.init(mockContext);
 
-        let response = await mockFramepostClient.mockRequest(
+        let response = await client.framePostClient.mockRequest(
             UiAppRequestType.REQUEST_AUTH_TOKENS
         );
 
         expect(response).toBeUndefined();
 
-        client.resolveAuthTokens('?a=abc&b=xyz');
+        authClient.resolveAuthTokens('?a=abc&b=xyz');
 
-        response = await mockFramepostClient.mockRequest(
+        response = await client.framePostClient.mockRequest(
             UiAppRequestType.REQUEST_AUTH_TOKENS
         );
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,18 +1,11 @@
-import type { ChildClient } from '@datadog/framepost';
-
+import type { DDClient } from '../client/client';
 import { UiAppRequestType } from '../constants';
-import type { Context } from '../types';
-import type { Logger } from '../utils/logger';
 
 export class DDAuthClient {
-    private readonly debug: boolean;
-    private readonly framePostClient: ChildClient<Context>;
-    private readonly logger: Logger;
+    private readonly client: DDClient;
 
-    constructor(debug: boolean, logger: Logger, framePostClient: ChildClient) {
-        this.debug = debug;
-        this.logger = logger;
-        this.framePostClient = framePostClient;
+    constructor(client: DDClient) {
+        this.client = client;
     }
 
     // Returns a promises that resolves with the params passed to the redirection url after a successful auth
@@ -22,7 +15,7 @@ export class DDAuthClient {
         authUrl: string,
         redirectUrlOrigin: string
     ): Promise<URLSearchParams> {
-        const paramsString = await this.framePostClient.request(
+        const paramsString = await this.client.framePostClient.request(
             UiAppRequestType.REQUEST_AUTH_TOKENS,
             { authUrl, redirectUrlOrigin }
         );
@@ -32,7 +25,7 @@ export class DDAuthClient {
     // Pass the URL query params. Must be called in a popup window opened by requestAuthTokens()
     // The counterpart to requestAuthTokens()
     resolveAuthTokens(paramsString: string) {
-        this.framePostClient.onRequest(
+        this.client.framePostClient.onRequest(
             UiAppRequestType.REQUEST_AUTH_TOKENS,
             () => paramsString
         );

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1,5 +1,6 @@
 import { init } from '..';
 
+import { UiAppEventType } from '../constants';
 import { MockFramePostChildClient, mockContext } from '../utils/testUtils';
 
 import { DDClient } from './client';
@@ -24,8 +25,10 @@ describe('client', () => {
 
         expect(client).toBeInstanceOf(Object);
     });
+});
 
-    test('has a getContext() method that returns app context after it is supplied from parent', async () => {
+describe('client.getContext()', () => {
+    test('returns app context after it is supplied from parent', async () => {
         const client = new DDClient();
 
         mockClient.init();
@@ -33,6 +36,22 @@ describe('client', () => {
         const context = await client.getContext();
 
         expect(context).toBe(mockContext);
+    });
+
+    test('updates returned context data on context_change event', async () => {
+        const client = new DDClient();
+
+        mockClient.init();
+
+        mockClient.mockEvent(UiAppEventType.CONTEXT_CHANGE, {
+            data: 'new context'
+        });
+
+        const context = await client.getContext();
+
+        expect(context).toEqual({
+            data: 'new context'
+        });
     });
 });
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -41,7 +41,7 @@ export class DDClient {
         this.debug = options.debug || DEFAULT_OPTIONS.debug;
 
         this.framePostClient = new ChildClient<Context>({
-            debug: this.debug,
+            debug: false, // 3p devs most likely dont need to see framepost debug messages
             profile: this.debug,
             context: {
                 sdkVersion: SDK_VERSION

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -10,7 +10,7 @@ import { DDModalClient } from '../modal/modal';
 import { DDSecretsClient } from '../secrets/secrets';
 import { DDSidePanelClient } from '../side-panel/side-panel';
 import type { Context, ClientContext, ClientOptions } from '../types';
-import { getLogger, Logger } from '../utils/logger';
+import { Logger } from '../utils/logger';
 import { DDWidgetContextMenuClient } from '../widget-context-menu/widget-context-menu';
 
 declare const SDK_VERSION: string;
@@ -48,7 +48,7 @@ export class DDClient {
             } as ClientContext
         });
 
-        this.logger = getLogger(options);
+        this.logger = new Logger(this);
 
         this.api = new DDAPIClient(this);
         this.auth = new DDAuthClient(this);
@@ -62,6 +62,12 @@ export class DDClient {
 
         this.events.on(UiAppEventType.CONTEXT_CHANGE, newContext => {
             this.context = newContext;
+
+            this.syncDebugMode(this.context);
+        });
+
+        this.getContext().then(context => {
+            this.syncDebugMode(context);
         });
     }
 
@@ -74,5 +80,10 @@ export class DDClient {
         }
 
         return this.context;
+    }
+
+    // Turn on debugger if dev mode is on in parent
+    private syncDebugMode(context: Context) {
+        this.debug = context.app.debug || this.debug;
     }
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -22,7 +22,7 @@ const DEFAULT_OPTIONS = {
 
 export class DDClient {
     private readonly host: string;
-    private context?: Context;
+    private context?: Context | null;
     readonly framePostClient: ChildClient<Context>;
     readonly logger: Logger;
     api: DDAPIClient;
@@ -74,8 +74,8 @@ export class DDClient {
     /**
      * Returns app context data, after it is sent from the parent
      */
-    async getContext(): Promise<Context> {
-        if (!this.context) {
+    async getContext(): Promise<Context | null> {
+        if (this.context === undefined) {
             this.context = await this.framePostClient.getContext();
         }
 
@@ -83,7 +83,7 @@ export class DDClient {
     }
 
     // Turn on debugger if dev mode is on in parent
-    private syncDebugMode(context: Context) {
-        this.debug = context.app.debug || this.debug;
+    private syncDebugMode(context: Context | null) {
+        this.debug = context?.app?.debug || this.debug;
     }
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -74,9 +74,9 @@ export class DDClient {
     /**
      * Returns app context data, after it is sent from the parent
      */
-    async getContext(): Promise<Context | null> {
-        if (this.context === undefined) {
-            this.context = await this.framePostClient.getContext();
+    async getContext(): Promise<Context> {
+        if (!this.context) {
+            this.context = await this.framePostClient.handshake();
         }
 
         return this.context;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ export enum UiAppFeatureType {
 export enum UiAppEventType {
     // General
     CUSTOM_EVENT = 'custom_event',
+    CONTEXT_CHANGE = 'context_change',
 
     // Dashboards
     DASHBOARD_COG_MENU_CLICK = 'dashboard_cog_menu_click',
@@ -83,7 +84,8 @@ export enum UiAppRequestType {
 
 // These event types are always allowed, regardless of what features have been enabled
 export const enabledEvents = new Set<UiAppEventType>([
-    UiAppEventType.CUSTOM_EVENT
+    UiAppEventType.CUSTOM_EVENT,
+    UiAppEventType.CONTEXT_CHANGE
 ]);
 
 export enum ModalSize {

--- a/src/dashboard-cog-menu/dashboard-cog-menu.test.ts
+++ b/src/dashboard-cog-menu/dashboard-cog-menu.test.ts
@@ -1,24 +1,19 @@
 import { UiAppFeatureType, UiAppRequestType, MenuItemType } from '../constants';
-import { getLogger } from '../utils/logger';
-import { MockFramePostChildClient, mockContext } from '../utils/testUtils';
+import { MockClient, mockContext } from '../utils/testUtils';
 
 import { DDDashboardCogMenuClient } from './dashboard-cog-menu';
 
-let mockFramepostClient: MockFramePostChildClient;
-let client: DDDashboardCogMenuClient;
+let client: MockClient;
+let cogMenuClient: DDDashboardCogMenuClient;
 
 beforeEach(() => {
-    mockFramepostClient = new MockFramePostChildClient();
-    client = new DDDashboardCogMenuClient(
-        true,
-        getLogger({ debug: true }),
-        mockFramepostClient as any
-    );
+    client = new MockClient();
+    cogMenuClient = new DDDashboardCogMenuClient(client as any);
 });
 
 describe('dashboardContextMenu.onRequestItems()', () => {
     test('Registers a handler returning an empty array on init', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -26,7 +21,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             }
         });
 
-        const response = await mockFramepostClient.mockRequest(
+        const response = await client.framePostClient.mockRequest(
             UiAppRequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             'data'
         );
@@ -35,7 +30,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
     });
 
     test('registers the provided handler when onRequestItems is called', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -56,9 +51,9 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             };
         });
 
-        client.onRequest(handler);
+        cogMenuClient.onRequest(handler);
 
-        const response = await mockFramepostClient.mockRequest(
+        const response = await client.framePostClient.mockRequest(
             UiAppRequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             'data'
         );
@@ -80,7 +75,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             .spyOn(console, 'error')
             .mockImplementation(() => {});
 
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -101,9 +96,9 @@ describe('dashboardContextMenu.onRequestItems()', () => {
         });
 
         // @ts-ignore
-        client.onRequest(handler);
+        cogMenuClient.onRequest(handler);
 
-        const response = await mockFramepostClient.mockRequest(
+        const response = await client.framePostClient.mockRequest(
             UiAppRequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             'data'
         );
@@ -118,7 +113,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
     });
 
     test('returns an unsubscribe hook that replaces with an empty handler', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -139,11 +134,11 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             };
         });
 
-        const unsubscribe = client.onRequest(handler);
+        const unsubscribe = cogMenuClient.onRequest(handler);
 
         unsubscribe();
 
-        const response = await mockFramepostClient.mockRequest(
+        const response = await client.framePostClient.mockRequest(
             UiAppRequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             'data'
         );

--- a/src/dashboard-cog-menu/dashboard-cog-menu.ts
+++ b/src/dashboard-cog-menu/dashboard-cog-menu.ts
@@ -30,13 +30,7 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
         const wrappedHandler = async (
             context: GetDashboardCogMenuItemsRequest
         ): Promise<GetDashboardCogMenuItemsResponse> => {
-            try {
-                await this.validateFeatureIsEnabled();
-            } catch (e) {
-                this.client.logger.error(e.message);
-
-                return emptyConfig;
-            }
+            await this.validateFeatureIsEnabled();
 
             const { items } = await requestHandler(context);
 

--- a/src/dashboard-cog-menu/dashboard-cog-menu.ts
+++ b/src/dashboard-cog-menu/dashboard-cog-menu.ts
@@ -1,24 +1,17 @@
-import type { ChildClient } from '@datadog/framepost';
-
+import type { DDClient } from '../client/client';
 import { UiAppFeatureType, UiAppRequestType } from '../constants';
 import { DDFeatureClient } from '../shared/feature-client';
 import type {
     GetDashboardCogMenuItemsRequest,
     GetDashboardCogMenuItemsResponse
 } from '../types';
-import type { Logger } from '../utils/logger';
 import { validateKey } from '../utils/utils';
 
 const emptyConfig: GetDashboardCogMenuItemsResponse = { items: [] };
 
 export class DDDashboardCogMenuClient extends DDFeatureClient {
-    constructor(debug: boolean, logger: Logger, framePostClient: ChildClient) {
-        super(
-            debug,
-            logger,
-            framePostClient,
-            UiAppFeatureType.DASHBOARD_COG_MENU
-        );
+    constructor(client: DDClient) {
+        super(client, UiAppFeatureType.DASHBOARD_COG_MENU);
 
         // initialize with an empty reponse handler
         this.onRequest(() => emptyConfig);
@@ -40,7 +33,7 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
             try {
                 await this.validateFeatureIsEnabled();
             } catch (e) {
-                this.logger.error(e.message);
+                this.client.logger.error(e.message);
 
                 return emptyConfig;
             }
@@ -52,7 +45,7 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
                     try {
                         validateKey(item);
                     } catch (e) {
-                        this.logger.error(e.message);
+                        this.client.logger.error(e.message);
 
                         return false;
                     }
@@ -62,7 +55,7 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
             };
         };
 
-        this.framePostClient.onRequest(
+        this.client.framePostClient.onRequest(
             UiAppRequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             wrappedHandler
         );

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -61,16 +61,18 @@ export class DDEventsClient {
         this.client
             .getContext()
             .then(context => {
-                const canHandleEvent = isEventEnabled(
-                    eventType,
-                    context.app.features
-                );
-
-                if (!canHandleEvent) {
-                    unsubscribe();
-                    this.client.logger.error(
-                        `Your app does not have the required features enabled to respond to events of type ${eventType}.`
+                if (context) {
+                    const canHandleEvent = isEventEnabled(
+                        eventType,
+                        context.app.features
                     );
+
+                    if (!canHandleEvent) {
+                        unsubscribe();
+                        this.client.logger.error(
+                            `Your app does not have the required features enabled to respond to events of type ${eventType}.`
+                        );
+                    }
                 }
             })
             .catch(() => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ let client: DDClient;
  */
 export const init = (
     options?: ClientOptions,
-    callback?: (context: Context) => void
+    callback?: (context: Context | null) => void
 ): DDClient => {
     if (!client) {
         client = new DDClient(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ let client: DDClient;
  */
 export const init = (
     options?: ClientOptions,
-    callback?: (context: Context | null) => void
+    callback?: (context: Context) => void
 ): DDClient => {
     if (!client) {
         client = new DDClient(options);

--- a/src/location/location.ts
+++ b/src/location/location.ts
@@ -1,22 +1,15 @@
-import type { ChildClient } from '@datadog/framepost';
-
+import type { DDClient } from '../client/client';
 import { UiAppRequestType } from '../constants';
-import type { Context } from '../types';
-import type { Logger } from '../utils/logger';
 
 export class DDLocationClient {
-    private readonly debug: boolean;
-    private readonly logger: Logger;
-    private readonly framePostClient: ChildClient<Context>;
+    private readonly client: DDClient;
 
-    constructor(debug: boolean, logger: Logger, framePostClient: ChildClient) {
-        this.debug = debug;
-        this.logger = logger;
-        this.framePostClient = framePostClient;
+    constructor(client: DDClient) {
+        this.client = client;
     }
 
     async goTo(url: string) {
-        return this.framePostClient.request<NavigateTopRequest>(
+        return this.client.framePostClient.request<NavigateTopRequest>(
             UiAppRequestType.NAVIGATE_TOP,
             {
                 url

--- a/src/modal/modal.test.ts
+++ b/src/modal/modal.test.ts
@@ -1,24 +1,19 @@
 import { UiAppFeatureType, UiAppRequestType } from '../constants';
-import { getLogger } from '../utils/logger';
-import { MockFramePostChildClient, mockContext } from '../utils/testUtils';
+import { MockClient, mockContext } from '../utils/testUtils';
 
 import { DDModalClient } from './modal';
 
-let mockFramepostClient: MockFramePostChildClient;
-let client: DDModalClient;
+let client: MockClient;
+let modalClient: DDModalClient;
 
 beforeEach(() => {
-    mockFramepostClient = new MockFramePostChildClient();
-    client = new DDModalClient(
-        true,
-        getLogger({ debug: true }),
-        mockFramepostClient as any
-    );
+    client = new MockClient();
+    modalClient = new DDModalClient(client as any);
 });
 
 describe('modal.open()', () => {
     test('sends an open modal request with definition to parent', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -26,10 +21,10 @@ describe('modal.open()', () => {
             }
         });
         const requestMock = jest
-            .spyOn(mockFramepostClient, 'request')
+            .spyOn(client.framePostClient, 'request')
             .mockImplementation(() => null);
 
-        const response = await client.open({
+        const response = await modalClient.open({
             key: 'my-modal',
             source: 'modal.html'
         });
@@ -45,7 +40,7 @@ describe('modal.open()', () => {
     });
 
     test('throws an error if modal definition is invalid', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -57,7 +52,7 @@ describe('modal.open()', () => {
 
         try {
             // @ts-ignore
-            await client.open({
+            await modalClient.open({
                 source: 'modal.html'
             });
         } catch (e) {
@@ -68,12 +63,12 @@ describe('modal.open()', () => {
     });
 
     test('throws an error if app does not have modals feature enabled', async () => {
-        mockFramepostClient.init();
+        client.framePostClient.init();
 
         let error;
 
         try {
-            await client.open({
+            await modalClient.open({
                 key: 'my-modal',
                 source: 'modal.html'
             });
@@ -87,7 +82,7 @@ describe('modal.open()', () => {
 
 describe('modal.close()', () => {
     test('sends an close modal request to parent', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -95,10 +90,10 @@ describe('modal.close()', () => {
             }
         });
         const requestMock = jest
-            .spyOn(mockFramepostClient, 'request')
+            .spyOn(client.framePostClient, 'request')
             .mockImplementation(() => null);
 
-        const response = await client.close('my-modal');
+        const response = await modalClient.close('my-modal');
 
         expect(response).toEqual(null);
 
@@ -109,12 +104,12 @@ describe('modal.close()', () => {
     });
 
     test('Throws an error if the app does not have the modals feature enabled', async () => {
-        mockFramepostClient.init();
+        client.framePostClient.init();
 
         let error;
 
         try {
-            await client.close('my-modal');
+            await modalClient.close('my-modal');
         } catch (e) {
             error = e;
         }

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -1,14 +1,12 @@
-import type { ChildClient } from '@datadog/framepost';
-
+import type { DDClient } from '../client/client';
 import { UiAppFeatureType, UiAppRequestType } from '../constants';
 import { DDFeatureClient } from '../shared/feature-client';
 import type { ModalDefinition } from '../types';
-import type { Logger } from '../utils/logger';
 import { validateKey } from '../utils/utils';
 
 export class DDModalClient extends DDFeatureClient {
-    constructor(debug: boolean, logger: Logger, framePostClient: ChildClient) {
-        super(debug, logger, framePostClient, UiAppFeatureType.MODALS);
+    constructor(client: DDClient) {
+        super(client, UiAppFeatureType.MODALS);
     }
 
     /**
@@ -19,9 +17,12 @@ export class DDModalClient extends DDFeatureClient {
         await this.validateFeatureIsEnabled();
 
         if (validateKey(definition)) {
-            return this.framePostClient.request(UiAppRequestType.OPEN_MODAL, {
-                definition
-            });
+            return this.client.framePostClient.request(
+                UiAppRequestType.OPEN_MODAL,
+                {
+                    definition
+                }
+            );
         }
     }
 
@@ -32,6 +33,9 @@ export class DDModalClient extends DDFeatureClient {
     async close(key?: string) {
         await this.validateFeatureIsEnabled();
 
-        return this.framePostClient.request(UiAppRequestType.CLOSE_MODAL, key);
+        return this.client.framePostClient.request(
+            UiAppRequestType.CLOSE_MODAL,
+            key
+        );
     }
 }

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -24,7 +24,7 @@ describe('client.get', () => {
         expect(response).toEqual(null);
         expect(requestMock).toHaveBeenCalledWith(
             UiAppRequestType.GET_SECRET,
-            'my-key'
+            'my-secret-key'
         );
     });
 });

--- a/src/secrets/secrets.ts
+++ b/src/secrets/secrets.ts
@@ -1,9 +1,6 @@
 /* eslint-disable no-undef */
-import type { ChildClient } from '@datadog/framepost';
-
+import type { DDClient } from '../client/client';
 import { UiAppRequestType } from '../constants';
-import type { Context } from '../types';
-import type { Logger } from '../utils/logger';
 
 const getLocalStorageKeys = () => {
     // we cannot use Obbjey.keys because it doesn't work with the mocked localStorage Object.keys(window.localStorage)
@@ -12,40 +9,36 @@ const getLocalStorageKeys = () => {
     );
 };
 export class DDSecretsClient {
-    private readonly debug: boolean;
-    private readonly framePostClient: ChildClient<Context>;
-    private readonly logger: Logger;
+    private readonly client: DDClient;
 
-    constructor(debug: boolean, logger: Logger, framePostClient: ChildClient) {
-        this.debug = debug;
-        this.logger = logger;
-        this.framePostClient = framePostClient;
+    constructor(client: DDClient) {
+        this.client = client;
 
         this.registerRequestHandlers();
     }
 
     private registerRequestHandlers() {
-        this.framePostClient.onRequest(
+        this.client.framePostClient.onRequest(
             UiAppRequestType.STORE_SECRET,
             this.handleStoreSecretRequest.bind(this)
         );
 
-        this.framePostClient.onRequest(
+        this.client.framePostClient.onRequest(
             UiAppRequestType.LOAD_SECRET,
             this.handleLoadSecretRequest.bind(this)
         );
 
-        this.framePostClient.onRequest(
+        this.client.framePostClient.onRequest(
             UiAppRequestType.LOAD_ALL_SECRETS,
             this.handleLoadAllSecretsRequest.bind(this)
         );
 
-        this.framePostClient.onRequest(
+        this.client.framePostClient.onRequest(
             UiAppRequestType.REMOVE_ALL_SECRETS,
             this.handleRemoveAllSecretsRequest.bind(this)
         );
 
-        this.framePostClient.onRequest(
+        this.client.framePostClient.onRequest(
             UiAppRequestType.REMOVE_SECRET,
             this.handleRemoveSecretRequest.bind(this)
         );
@@ -113,18 +106,24 @@ export class DDSecretsClient {
 
     // returns a promises that resolves with the decrypted secret for a given key
     async get(key: string) {
-        return this.framePostClient.request(UiAppRequestType.GET_SECRET, key);
+        return this.client.framePostClient.request(
+            UiAppRequestType.GET_SECRET,
+            key
+        );
     }
 
     async set(key: string, data: string) {
-        return this.framePostClient.request(UiAppRequestType.SET_SECRET, {
-            key,
-            data
-        });
+        return this.client.framePostClient.request(
+            UiAppRequestType.SET_SECRET,
+            {
+                key,
+                data
+            }
+        );
     }
 
     async remove(key: string) {
-        return this.framePostClient.request(
+        return this.client.framePostClient.request(
             UiAppRequestType.REMOVE_SECRET_PUBLIC,
             key
         );

--- a/src/shared/feature-client.ts
+++ b/src/shared/feature-client.ts
@@ -1,32 +1,20 @@
-import type { ChildClient } from '@datadog/framepost';
-
+import type { DDClient } from '../client/client';
 import type { UiAppFeatureType } from '../constants';
-import type { Context } from '../types';
-import type { Logger } from '../utils/logger';
 import { isFeatureEnabled } from '../utils/utils';
 
 export class DDFeatureClient {
-    protected readonly debug: boolean;
-    protected readonly logger: Logger;
-    protected readonly framePostClient: ChildClient<Context>;
+    protected readonly client: DDClient;
     protected readonly featureType: UiAppFeatureType;
 
-    constructor(
-        debug: boolean,
-        logger: Logger,
-        framePostClient: ChildClient,
-        featureType: UiAppFeatureType
-    ) {
-        this.debug = debug;
-        this.logger = logger;
-        this.framePostClient = framePostClient;
+    constructor(client: DDClient, featureType: UiAppFeatureType) {
+        this.client = client;
         this.featureType = featureType;
     }
 
     private async isEnabled() {
         const {
             app: { features }
-        } = await this.framePostClient.getContext();
+        } = await this.client.getContext();
 
         return isFeatureEnabled(this.featureType, features);
     }

--- a/src/shared/feature-client.ts
+++ b/src/shared/feature-client.ts
@@ -11,15 +11,24 @@ export class DDFeatureClient {
         this.featureType = featureType;
     }
 
-    private async isEnabled() {
+    private async isEnabled(): Promise<boolean> {
+        const context = await this.client.getContext();
+
+        if (!context) {
+            return false;
+        }
+
         const {
             app: { features }
-        } = await this.client.getContext();
+        } = context;
 
         return isFeatureEnabled(this.featureType, features);
     }
 
     protected async validateFeatureIsEnabled() {
+        // will throw a handshake error if handshake fails
+        await this.client.framePostClient.handshake();
+
         const isEnabled = await this.isEnabled();
 
         if (!isEnabled) {

--- a/src/side-panel/side-panel.test.ts
+++ b/src/side-panel/side-panel.test.ts
@@ -1,24 +1,19 @@
 import { UiAppFeatureType, UiAppRequestType } from '../constants';
-import { getLogger } from '../utils/logger';
-import { MockFramePostChildClient, mockContext } from '../utils/testUtils';
+import { mockContext, MockClient } from '../utils/testUtils';
 
 import { DDSidePanelClient } from './side-panel';
 
-let mockFramepostClient: MockFramePostChildClient;
-let client: DDSidePanelClient;
+let client: MockClient;
+let sidePanelClient: DDSidePanelClient;
 
 beforeEach(() => {
-    mockFramepostClient = new MockFramePostChildClient();
-    client = new DDSidePanelClient(
-        true,
-        getLogger({ debug: true }),
-        mockFramepostClient as any
-    );
+    client = new MockClient();
+    sidePanelClient = new DDSidePanelClient(client as any);
 });
 
 describe('sidePanel.open()', () => {
     test('sends an open request with definition to parent', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -26,10 +21,10 @@ describe('sidePanel.open()', () => {
             }
         });
         const requestMock = jest
-            .spyOn(mockFramepostClient, 'request')
+            .spyOn(client.framePostClient, 'request')
             .mockImplementation(() => null);
 
-        const response = await client.open({
+        const response = await sidePanelClient.open({
             key: 'my-panel',
             source: 'panel.html'
         });
@@ -48,7 +43,7 @@ describe('sidePanel.open()', () => {
     });
 
     test('sends an open request with definition and context to parent', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -56,10 +51,10 @@ describe('sidePanel.open()', () => {
             }
         });
         const requestMock = jest
-            .spyOn(mockFramepostClient, 'request')
+            .spyOn(client.framePostClient, 'request')
             .mockImplementation(() => null);
 
-        const response = await client.open(
+        const response = await sidePanelClient.open(
             {
                 key: 'my-panel',
                 source: 'panel.html'
@@ -82,7 +77,7 @@ describe('sidePanel.open()', () => {
     });
 
     test('throws an error if definition is invalid', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -94,7 +89,7 @@ describe('sidePanel.open()', () => {
 
         try {
             // @ts-ignore
-            await client.open({
+            await sidePanelClient.open({
                 source: 'panel.html'
             });
         } catch (e) {
@@ -105,12 +100,12 @@ describe('sidePanel.open()', () => {
     });
 
     test('throws an error if app does not have the feature enabled', async () => {
-        mockFramepostClient.init();
+        client.framePostClient.init();
 
         let error;
 
         try {
-            await client.open({
+            await sidePanelClient.open({
                 key: 'my-panel',
                 source: 'panel.html'
             });
@@ -124,7 +119,7 @@ describe('sidePanel.open()', () => {
 
 describe('sidePanel.close()', () => {
     test('sends an close request to parent', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -132,10 +127,10 @@ describe('sidePanel.close()', () => {
             }
         });
         const requestMock = jest
-            .spyOn(mockFramepostClient, 'request')
+            .spyOn(client.framePostClient, 'request')
             .mockImplementation(() => null);
 
-        const response = await client.close('my-panel');
+        const response = await sidePanelClient.close('my-panel');
 
         expect(response).toEqual(null);
 
@@ -146,12 +141,12 @@ describe('sidePanel.close()', () => {
     });
 
     test('Throws an error if the app does not have the feature enabled', async () => {
-        mockFramepostClient.init();
+        client.framePostClient.init();
 
         let error;
 
         try {
-            await client.close('my-panel');
+            await sidePanelClient.close('my-panel');
         } catch (e) {
             error = e;
         }

--- a/src/side-panel/side-panel.ts
+++ b/src/side-panel/side-panel.ts
@@ -1,14 +1,12 @@
-import type { ChildClient } from '@datadog/framepost';
-
+import type { DDClient } from '../client/client';
 import { UiAppFeatureType, UiAppRequestType } from '../constants';
 import { DDFeatureClient } from '../shared/feature-client';
 import { SidePanelDefinition } from '../types';
-import type { Logger } from '../utils/logger';
 import { validateKey } from '../utils/utils';
 
 export class DDSidePanelClient extends DDFeatureClient {
-    constructor(debug: boolean, logger: Logger, framePostClient: ChildClient) {
-        super(debug, logger, framePostClient, UiAppFeatureType.SIDE_PANELS);
+    constructor(client: DDClient) {
+        super(client, UiAppFeatureType.SIDE_PANELS);
     }
 
     /**
@@ -19,7 +17,7 @@ export class DDSidePanelClient extends DDFeatureClient {
         await this.validateFeatureIsEnabled();
 
         if (validateKey(definition)) {
-            return this.framePostClient.request(
+            return this.client.framePostClient.request(
                 UiAppRequestType.OPEN_SIDE_PANEL,
                 { definition, args }
             );
@@ -33,7 +31,7 @@ export class DDSidePanelClient extends DDFeatureClient {
     async close(key?: string) {
         await this.validateFeatureIsEnabled();
 
-        return this.framePostClient.request(
+        return this.client.framePostClient.request(
             UiAppRequestType.CLOSE_SIDE_PANEL,
             key
         );

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export interface AppContext {
     };
     // list of enabled features
     features: UiAppFeatureType[];
+    // is app running in debug mode
+    debug: boolean;
 }
 
 // TODO: Could colocate these feature-specific types with feature defs

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,25 +1,22 @@
 /* eslint-disable no-console */
-import { ClientOptions } from '../types';
+import type { DDClient } from '../client/client';
 
-export interface Logger {
-    log(message: string): void;
-    error(message: string): void;
-}
+export class Logger {
+    private readonly client: DDClient;
 
-export const getLogger = (options: ClientOptions): Logger => {
-    if (options.debug) {
-        return {
-            log(message: string) {
-                return console.log(`dd-apps: ${message}`);
-            },
-            error(message: string) {
-                return console.error(`dd-apps: ${message}`);
-            }
-        };
-    } else {
-        return {
-            log() {},
-            error() {}
-        };
+    constructor(client: DDClient) {
+        this.client = client;
     }
-};
+
+    log(message: string) {
+        if (this.client.debug) {
+            return console.log(`dd-apps: ${message}`);
+        }
+    }
+
+    error(message: string) {
+        if (this.client.debug) {
+            return console.error(`dd-apps: ${message}`);
+        }
+    }
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -8,15 +8,20 @@ export class Logger {
         this.client = client;
     }
 
+    private getPrefix(): string {
+        return `dd-apps@${window.location.href}: `; // eslint-disable-line
+    }
+
+    // TODO: would be nice to prefix with some info about the app
     log(message: string) {
         if (this.client.debug) {
-            return console.log(`dd-apps: ${message}`);
+            return console.log(`${this.getPrefix()}${message}`);
         }
     }
 
     error(message: string) {
         if (this.client.debug) {
-            return console.error(`dd-apps: ${message}`);
+            return console.error(`${this.getPrefix()}${message}`);
         }
     }
 }

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -1,6 +1,8 @@
 import { UiAppFeatureType } from '../constants';
 import { Context } from '../types';
 
+import { getLogger, Logger } from './logger';
+
 export interface Deferred<T> {
     resolve: (t: T) => void;
     reject: (t: T) => void;
@@ -154,5 +156,18 @@ export class MockLocalStorage {
 
     key(index: number): string | null {
         return Object.keys(this.store)[index];
+    }
+}
+
+export class MockClient {
+    framePostClient: MockFramePostChildClient;
+    logger: Logger;
+    constructor() {
+        this.framePostClient = new MockFramePostChildClient();
+        this.logger = getLogger({ debug: true });
+    }
+
+    getContext() {
+        return this.framePostClient.getContext();
     }
 }

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -1,7 +1,7 @@
 import { UiAppFeatureType } from '../constants';
 import { Context } from '../types';
 
-import { getLogger, Logger } from './logger';
+import { Logger } from './logger';
 
 export interface Deferred<T> {
     resolve: (t: T) => void;
@@ -47,7 +47,8 @@ export const mockContext: Context = {
             id: 12345,
             name: 'Corporate overlord'
         },
-        features: [UiAppFeatureType.DASHBOARD_COG_MENU]
+        features: [UiAppFeatureType.DASHBOARD_COG_MENU],
+        debug: true
     }
 };
 
@@ -162,9 +163,11 @@ export class MockLocalStorage {
 export class MockClient {
     framePostClient: MockFramePostChildClient;
     logger: Logger;
+    debug: boolean = true;
+
     constructor() {
         this.framePostClient = new MockFramePostChildClient();
-        this.logger = getLogger({ debug: true });
+        this.logger = new Logger(this as any);
     }
 
     getContext() {

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -77,6 +77,10 @@ export class MockFramePostChildClient {
         return context;
     }
 
+    handshake() {
+        return this.getContext();
+    }
+
     on(eventType: string, handler: (arg?: any) => any): () => void {
         const subscriptionId = uniqueInt().toString();
 

--- a/src/widget-context-menu/widget-context-menu.test.ts
+++ b/src/widget-context-menu/widget-context-menu.test.ts
@@ -1,24 +1,19 @@
 import { UiAppFeatureType, UiAppRequestType, MenuItemType } from '../constants';
-import { getLogger } from '../utils/logger';
-import { MockFramePostChildClient, mockContext } from '../utils/testUtils';
+import { mockContext, MockClient } from '../utils/testUtils';
 
 import { DDWidgetContextMenuClient } from './widget-context-menu';
 
-let mockFramepostClient: MockFramePostChildClient;
-let client: DDWidgetContextMenuClient;
+let client: MockClient;
+let widgetContextMenuClient: DDWidgetContextMenuClient;
 
 beforeEach(() => {
-    mockFramepostClient = new MockFramePostChildClient();
-    client = new DDWidgetContextMenuClient(
-        true,
-        getLogger({ debug: true }),
-        mockFramepostClient as any
-    );
+    client = new MockClient();
+    widgetContextMenuClient = new DDWidgetContextMenuClient(client as any);
 });
 
 describe('dashboardContextMenu.onRequestItems()', () => {
     test('Registers a handler returning an empty array on init', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -26,7 +21,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             }
         });
 
-        const response = await mockFramepostClient.mockRequest(
+        const response = await client.framePostClient.mockRequest(
             UiAppRequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             'data'
         );
@@ -35,7 +30,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
     });
 
     test('registers the provided handler when onRequestItems is called', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -56,9 +51,9 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             };
         });
 
-        client.onRequest(handler);
+        widgetContextMenuClient.onRequest(handler);
 
-        const response = await mockFramepostClient.mockRequest(
+        const response = await client.framePostClient.mockRequest(
             UiAppRequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             'data'
         );
@@ -80,7 +75,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             .spyOn(console, 'error')
             .mockImplementation(() => {});
 
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -101,9 +96,9 @@ describe('dashboardContextMenu.onRequestItems()', () => {
         });
 
         // @ts-ignore
-        client.onRequest(handler);
+        widgetContextMenuClient.onRequest(handler);
 
-        const response = await mockFramepostClient.mockRequest(
+        const response = await client.framePostClient.mockRequest(
             UiAppRequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             'data'
         );
@@ -118,7 +113,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
     });
 
     test('returns an unsubscribe hook that replaces with an empty handler', async () => {
-        mockFramepostClient.init({
+        client.framePostClient.init({
             ...mockContext,
             app: {
                 ...mockContext.app,
@@ -139,11 +134,11 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             };
         });
 
-        const unsubscribe = client.onRequest(handler);
+        const unsubscribe = widgetContextMenuClient.onRequest(handler);
 
         unsubscribe();
 
-        const response = await mockFramepostClient.mockRequest(
+        const response = await client.framePostClient.mockRequest(
             UiAppRequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             'data'
         );

--- a/src/widget-context-menu/widget-context-menu.ts
+++ b/src/widget-context-menu/widget-context-menu.ts
@@ -1,24 +1,17 @@
-import type { ChildClient } from '@datadog/framepost';
-
+import type { DDClient } from '../client/client';
 import { UiAppFeatureType, UiAppRequestType } from '../constants';
 import { DDFeatureClient } from '../shared/feature-client';
 import type {
     GetWidgetContextMenuItemsRequest,
     GetWidgetContextMenuItemsResponse
 } from '../types';
-import type { Logger } from '../utils/logger';
 import { validateKey } from '../utils/utils';
 
 const emptyConfig: GetWidgetContextMenuItemsResponse = { items: [] };
 
 export class DDWidgetContextMenuClient extends DDFeatureClient {
-    constructor(debug: boolean, logger: Logger, framePostClient: ChildClient) {
-        super(
-            debug,
-            logger,
-            framePostClient,
-            UiAppFeatureType.WIDGET_CONTEXT_MENU
-        );
+    constructor(client: DDClient) {
+        super(client, UiAppFeatureType.WIDGET_CONTEXT_MENU);
 
         // initialize with an empty reponse handler
         this.onRequest(() => emptyConfig);
@@ -40,7 +33,7 @@ export class DDWidgetContextMenuClient extends DDFeatureClient {
             try {
                 await this.validateFeatureIsEnabled();
             } catch (e) {
-                this.logger.error(e.message);
+                this.client.logger.error(e.message);
 
                 return emptyConfig;
             }
@@ -52,7 +45,7 @@ export class DDWidgetContextMenuClient extends DDFeatureClient {
                     try {
                         validateKey(item);
                     } catch (e) {
-                        this.logger.error(e.message);
+                        this.client.logger.error(e.message);
 
                         return false;
                     }
@@ -62,7 +55,7 @@ export class DDWidgetContextMenuClient extends DDFeatureClient {
             };
         };
 
-        this.framePostClient.onRequest(
+        this.client.framePostClient.onRequest(
             UiAppRequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             wrappedHandler
         );

--- a/src/widget-context-menu/widget-context-menu.ts
+++ b/src/widget-context-menu/widget-context-menu.ts
@@ -30,13 +30,7 @@ export class DDWidgetContextMenuClient extends DDFeatureClient {
         const wrappedHandler = async (
             context: GetWidgetContextMenuItemsRequest
         ): Promise<GetWidgetContextMenuItemsResponse> => {
-            try {
-                await this.validateFeatureIsEnabled();
-            } catch (e) {
-                this.client.logger.error(e.message);
-
-                return emptyConfig;
-            }
+            await this.validateFeatureIsEnabled();
 
             const { items } = await requestHandler(context);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
         "moduleResolution": "node",
         "esModuleInterop": true,
         "resolveJsonModule": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "skipLibCheck": true
     },
     "exclude": ["dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,9 +279,9 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@datadog/framepost@git://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136":
+"@datadog/framepost@https://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136":
   version "0.2.1"
-  resolved "git://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136"
+  resolved "https://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136"
 
 "@eslint/eslintrc@^0.2.1":
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,9 +279,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@datadog/framepost@https://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136":
-  version "0.2.1"
-  resolved "https://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136"
+"@datadog/framepost@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@datadog/framepost/-/framepost-0.2.2.tgz#3e1cd271f69f9359345fcf765a1c5a6d60cb56fc"
+  integrity sha512-3OpjjpiRUaJCp/GVjuZl8zNcfQ1uVXcl0ZvEg29J2z01mdXO11c8Wfuwhh87KXYMn9vtHrwasTV39EXLmF7ULg==
 
 "@eslint/eslintrc@^0.2.1":
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,10 +279,9 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@datadog/framepost@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@datadog/framepost/-/framepost-0.2.0.tgz#c625745de0fde5851d17ece1e585d214704341cf"
-  integrity sha512-Gl0emwxnnHE2av4kTo4N4bI2Wg/S9ApKrYyp+pvVEv8YwRFxP37FXURMrJS+33ZMusxhlXS9bRqUJuqSixcEvQ==
+"@datadog/framepost@git://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136":
+  version "0.2.1"
+  resolved "git://github.com/DataDog/framepost.git#263c75d619ada57833e0cb6f0d7de386a3ccc136"
 
 "@eslint/eslintrc@^0.2.1":
   version "0.2.1"


### PR DESCRIPTION
* Supports new context_change event, sent from the parent whenever the frame context changes. The event can be subscribed to
* Uses ^ to update data returned from client.getContext() so that it is always current
* Upgrade framepost to take advantage of error handling updates in https://github.com/DataDog/framepost/pull/6
* Turn on debug mode based on context data sent from parent. This allows debug mode to be turned on at runtime, by the user in web-ui, rather than by the developer at build time
* Turns off debug mode in framepost. This optimizes for 3p developer experience, since they will not likely care about framepost internals. We can add a 'master of the universe' mode for DD ui apps devs later if we need it
* Prefix logs with the current url. This allows 3p devs to tell which iframes the debug messages are coming from