### PR TITLE
[requests] Add DashboardClient for sending events from SDK to parent dashboard

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -10,7 +10,7 @@ export class DDActionsClient {
         this.client = client;
     }
 
-    async setDashboardCursorRequest({ timestamp }: SetDashboardCursorRequest) {
+    async setDashboardCursor({ timestamp }: SetDashboardCursorRequest) {
         return this.client.framePostClient.request<SetDashboardCursorRequest>(
             UiAppRequestType.SET_DASHBOARD_CURSOR,
             {
@@ -47,5 +47,5 @@ interface SetDashboardCursorRequest {
 }
 
 interface SetDashboardTemplateVarsRequest {
-    vars: Record<string, string>; // Doesn't have to set every one. Parent takes care of merging with current. TODO: permit null state?
+    vars: Record<string, string>; // Doesn't have to set every var. Parent takes care of merging with current.
 }

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1,0 +1,51 @@
+// Actions are UiAppRequestType requests that are sent from Datadog to the parent dashboard
+import type { DDClient } from '../client/client';
+import { UiAppRequestType } from '../constants';
+import type { Timeframe } from '../types';
+
+export class DDActionsClient {
+    private readonly client: DDClient;
+
+    constructor(client: DDClient) {
+        this.client = client;
+    }
+
+    async setDashboardCursorRequest({ timestamp }: SetDashboardCursorRequest) {
+        return this.client.framePostClient.request<SetDashboardCursorRequest>(
+            UiAppRequestType.SET_DASHBOARD_CURSOR,
+            {
+                timestamp
+            }
+        );
+    }
+
+    async setDashboardTimeframe({ timeframe }: SetDashboardTimeframeRequest) {
+        return this.client.framePostClient.request<SetDashboardTimeframeRequest>(
+            UiAppRequestType.SET_DASHBOARD_TIMEFRAME,
+            {
+                timeframe
+            }
+        );
+    }
+
+    async setDashboardTemplateVars({ vars }: SetDashboardTemplateVarsRequest) {
+        return this.client.framePostClient.request<SetDashboardTemplateVarsRequest>(
+            UiAppRequestType.SET_DASHBOARD_TEMPLATE_VARS,
+            {
+                vars
+            }
+        );
+    }
+}
+
+interface SetDashboardTimeframeRequest {
+    timeframe: Timeframe;
+}
+
+interface SetDashboardCursorRequest {
+    timestamp: number | null; // Match
+}
+
+interface SetDashboardTemplateVarsRequest {
+    vars: Record<string, string>; // Doesn't have to set every one. Parent takes care of merging with current. TODO: permit null state?
+}

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,5 +1,6 @@
 import { ChildClient } from '@datadog/framepost';
 
+import { DDActionsClient } from '../actions/actions';
 import { DDAPIClient } from '../api/api';
 import { DDAuthClient } from '../auth/auth';
 import { UiAppEventType, Host } from '../constants';
@@ -26,6 +27,7 @@ export class DDClient {
     readonly framePostClient: ChildClient<Context>;
     readonly logger: Logger;
     api: DDAPIClient;
+    actions: DDActionsClient;
     debug: boolean;
     events: DDEventsClient;
     dashboardCogMenu: DDDashboardCogMenuClient;
@@ -50,6 +52,7 @@ export class DDClient {
 
         this.logger = new Logger(this);
 
+        this.actions = new DDActionsClient(this);
         this.api = new DDAPIClient(this);
         this.auth = new DDAuthClient(this);
         this.events = new DDEventsClient(this);

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,6 +1,6 @@
 import { ChildClient } from '@datadog/framepost';
 
-import { DDActionsClient } from '../actions/actions';
+import { DDDashboardClient } from '../dashboard/dashboard';
 import { DDAPIClient } from '../api/api';
 import { DDAuthClient } from '../auth/auth';
 import { UiAppEventType, Host } from '../constants';
@@ -27,7 +27,7 @@ export class DDClient {
     readonly framePostClient: ChildClient<Context>;
     readonly logger: Logger;
     api: DDAPIClient;
-    actions: DDActionsClient;
+    dashboard: DDDashboardClient;
     debug: boolean;
     events: DDEventsClient;
     dashboardCogMenu: DDDashboardCogMenuClient;
@@ -52,10 +52,10 @@ export class DDClient {
 
         this.logger = new Logger(this);
 
-        this.actions = new DDActionsClient(this);
         this.api = new DDAPIClient(this);
         this.auth = new DDAuthClient(this);
         this.events = new DDEventsClient(this);
+        this.dashboard = new DDDashboardClient(this);
         this.dashboardCogMenu = new DDDashboardCogMenuClient(this);
         this.location = new DDLocationClient(this);
         this.modal = new DDModalClient(this);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,7 +79,12 @@ export enum UiAppRequestType {
     GET_WIDGET_CONTEXT_MENU_ITEMS = 'get_widget_context_menu_items',
 
     // Dashboard Cog Menu
-    GET_DASHBOARD_COG_MENU_ITEMS = 'get_dashboard_cog_menu_items'
+    GET_DASHBOARD_COG_MENU_ITEMS = 'get_dashboard_cog_menu_items',
+
+    // Notify parent
+    SET_DASHBOARD_TEMPLATE_VARS = 'set_dashboard_template_vars',
+    SET_DASHBOARD_TIMEFRAME = 'set_dashboard_timeframe',
+    SET_DASHBOARD_CURSOR = 'set_dashboard_cursor',
 }
 
 // These event types are always allowed, regardless of what features have been enabled

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,7 +82,6 @@ export enum UiAppRequestType {
     GET_DASHBOARD_COG_MENU_ITEMS = 'get_dashboard_cog_menu_items',
 
     // Notify parent
-    SET_DASHBOARD_TEMPLATE_VARS = 'set_dashboard_template_vars',
     SET_DASHBOARD_TIMEFRAME = 'set_dashboard_timeframe',
     SET_DASHBOARD_CURSOR = 'set_dashboard_cursor',
 }

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -3,14 +3,14 @@ import type { DDClient } from '../client/client';
 import { UiAppRequestType } from '../constants';
 import type { Timeframe } from '../types';
 
-export class DDActionsClient {
+export class DDDashboardClient {
     private readonly client: DDClient;
 
     constructor(client: DDClient) {
         this.client = client;
     }
 
-    async setDashboardCursor({ timestamp }: SetDashboardCursorRequest) {
+    async setCursor({ timestamp }: SetDashboardCursorRequest) {
         return this.client.framePostClient.request<SetDashboardCursorRequest>(
             UiAppRequestType.SET_DASHBOARD_CURSOR,
             {
@@ -19,7 +19,7 @@ export class DDActionsClient {
         );
     }
 
-    async setDashboardTimeframe({ timeframe }: SetDashboardTimeframeRequest) {
+    async setTimeframe({ timeframe }: SetDashboardTimeframeRequest) {
         return this.client.framePostClient.request<SetDashboardTimeframeRequest>(
             UiAppRequestType.SET_DASHBOARD_TIMEFRAME,
             {
@@ -28,7 +28,7 @@ export class DDActionsClient {
         );
     }
 
-    async setDashboardTemplateVars({ vars }: SetDashboardTemplateVarsRequest) {
+    async setTemplateVars({ vars }: SetDashboardTemplateVarsRequest) {
         return this.client.framePostClient.request<SetDashboardTemplateVarsRequest>(
             UiAppRequestType.SET_DASHBOARD_TEMPLATE_VARS,
             {

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -34,5 +34,5 @@ interface SetDashboardTimeframeRequest {
 }
 
 interface SetDashboardCursorRequest {
-    timestamp: number | null; // Match
+    timestamp: number | null;
 }

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -27,15 +27,6 @@ export class DDDashboardClient {
             }
         );
     }
-
-    async setTemplateVars({ vars }: SetDashboardTemplateVarsRequest) {
-        return this.client.framePostClient.request<SetDashboardTemplateVarsRequest>(
-            UiAppRequestType.SET_DASHBOARD_TEMPLATE_VARS,
-            {
-                vars
-            }
-        );
-    }
 }
 
 interface SetDashboardTimeframeRequest {
@@ -44,8 +35,4 @@ interface SetDashboardTimeframeRequest {
 
 interface SetDashboardCursorRequest {
     timestamp: number | null; // Match
-}
-
-interface SetDashboardTemplateVarsRequest {
-    vars: Record<string, string>; // Doesn't have to set every var. Parent takes care of merging with current.
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,14 @@
         "esModuleInterop": true,
         "resolveJsonModule": true,
         "sourceMap": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "target": "es5",
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "esnext"
+        ],
     },
-    "exclude": ["dist"]
+    "exclude": ["dist"],
+
 }


### PR DESCRIPTION
## Motivation

- Enable UI App developers to trigger state changes in the parent Dashboard (Cursor and Timeframe)

## Changes

- Modeled after the Secrets / Location clients
- Didn't name this the `requests` client  since it's not the only client making requests, but open to renaming. To me, an `action` is something the child asks a parent dashboard to do. (This could also be a `DashboardActions` client depending on whether widgets may live on pages that aren't dashboards someday and need to operate with the same API, or they'd behave differently).


## Testing

- See https://github.com/DataDog/web-ui/pull/30273 for corresponding PR with listeners