### PR TITLE
[UI Apps] Conform FramePost client handshake timeout to ParentClient in web-ui

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -2,7 +2,7 @@ import { ChildClient } from '@datadog/framepost';
 
 import { DDAPIClient } from '../api/api';
 import { DDAuthClient } from '../auth/auth';
-import { UiAppEventType, Host } from '../constants';
+import { UiAppEventType, Host, FramePostClientSettings } from '../constants';
 import { DDDashboardCogMenuClient } from '../dashboard-cog-menu/dashboard-cog-menu';
 import { DDDashboardClient } from '../dashboard/dashboard';
 import { DDEventsClient } from '../events/events';
@@ -55,7 +55,8 @@ export class DDClient {
         }
 
         this.framePostClient = new ChildClient<Context>({
-            debug: false, // 3p devs most likely dont need to see framepost debug messages
+            debug: FramePostClientSettings.DEBUG,
+            requestTimeout: FramePostClientSettings.CLIENT_REQUEST_TIMEOUT,
             profile: this.debug,
             context: {
                 sdkVersion: SDK_VERSION,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,8 +49,8 @@ export enum IFrameApiRequestMethod {
 export const FramePostClientSettings = Object.freeze({
     // 3p devs most likely dont need to see framepost debug messages
     DEBUG: false,
-    // TODO: Revisit approach; the 10s is to unblock specific app developers
-    // Must match `HANDSHAKE_TIMEOUT` constant in web-ui
+    // TODO: Revisit approach; the 10s is to unblock 3p devs
+    // Must match server-side constant
     CLIENT_REQUEST_TIMEOUT: 10000
 });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,6 +46,14 @@ export enum IFrameApiRequestMethod {
     DELETE = 'DELETE'
 }
 
+export const FramePostClientSettings = Object.freeze({
+    // 3p devs most likely dont need to see framepost debug messages
+    DEBUG: false,
+    // TODO: Revisit approach; the 10s is to unblock specific app developers
+    // Must match `HANDSHAKE_TIMEOUT` constant in web-ui
+    CLIENT_REQUEST_TIMEOUT: 10000
+});
+
 // "Requests" are distinct from events in that the sdk client expects a response
 // from the frameManager, or vice-versa. This is useful when the child frames
 // ask the parent frames to perform an operation.


### PR DESCRIPTION
## Motivation

To conform other usages of FramePost, we're increasing the request timeout in the SDK's FramePost client.

## Changes

This change increases the handshake timeout to **10,000ms**. I've also abstracted the FramePost settings to a separate constant.