### PR TITLE
Custom widget dynamic items/options

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -3,7 +3,6 @@ import { ChildClient } from '@datadog/framepost';
 import { DDAPIClient } from '../api/api';
 import { DDAuthClient } from '../auth/auth';
 import { UiAppEventType, Host } from '../constants';
-import { DDDashboardCogMenuClient } from '../dashboard-cog-menu/dashboard-cog-menu';
 import { DDDashboardClient } from '../dashboard/dashboard';
 import { DDEventsClient } from '../events/events';
 import { DDLocationClient } from '../location/location';
@@ -35,7 +34,6 @@ export class DDClient {
     dashboard: DDDashboardClient;
     debug: boolean;
     events: DDEventsClient;
-    dashboardCogMenu: DDDashboardCogMenuClient;
     location: DDLocationClient;
     modal: DDModalClient;
     sidePanel: DDSidePanelClient;
@@ -69,7 +67,6 @@ export class DDClient {
         this.auth = new DDAuthClient(this, options.authProvider);
         this.events = new DDEventsClient(this);
         this.dashboard = new DDDashboardClient(this);
-        this.dashboardCogMenu = new DDDashboardCogMenuClient(this);
         this.location = new DDLocationClient(this);
         this.modal = new DDModalClient(this);
         this.sidePanel = new DDSidePanelClient(this);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,7 @@ export enum UiAppEventType {
     DASHBOARD_CURSOR_CHANGE = 'dashboard_cursor_change',
     DASHBOARD_TEMPLATE_VAR_CHANGE = 'dashboard_template_var_change',
     DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE = 'dashboard_custom_widget_options_change',
+    DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE = 'dashboard_custom_widget_options_update',
 
     // Modals
     MODAL_CLOSE = 'modal_close',
@@ -92,6 +93,7 @@ export enum UiAppRequestType {
     SET_DASHBOARD_CURSOR = 'set_dashboard_cursor',
 
     // Dashboard Custom Widget
+    GET_DASHBOARD_CUSTOM_WIDGET_ITEMS = 'get_dashboard_custom_widget_items',
     GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS = 'get_dashboard_custom_widget_options'
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,7 +89,10 @@ export enum UiAppRequestType {
 
     // Notify parent
     SET_DASHBOARD_TIMEFRAME = 'set_dashboard_timeframe',
-    SET_DASHBOARD_CURSOR = 'set_dashboard_cursor'
+    SET_DASHBOARD_CURSOR = 'set_dashboard_cursor',
+
+    // Dashboard Custom Widget
+    GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS = 'get_dashboard_custom_widget_options'
 }
 
 // These event types are always allowed, regardless of what features have been enabled
@@ -124,4 +127,9 @@ export enum AuthStateStatus {
     INITIATED = 'initiated',
     SUCCESS = 'success',
     FAILED = 'failed'
+}
+
+export enum WidgetOptionItemType {
+    BOOLEAN = 'boolean',
+    STRING = 'string'
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -93,8 +93,7 @@ export enum UiAppRequestType {
     SET_DASHBOARD_CURSOR = 'set_dashboard_cursor',
 
     // Dashboard Custom Widget
-    GET_DASHBOARD_CUSTOM_WIDGET_ITEMS = 'get_dashboard_custom_widget_items',
-    GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS = 'get_dashboard_custom_widget_options'
+    GET_DASHBOARD_CUSTOM_WIDGET_ITEMS = 'get_dashboard_custom_widget_items'
 }
 
 // These event types are always allowed, regardless of what features have been enabled

--- a/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.test.ts
+++ b/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.test.ts
@@ -1,5 +1,9 @@
-import { UiAppFeatureType, UiAppRequestType, MenuItemType } from '../constants';
-import { MockClient, mockContext } from '../utils/testUtils';
+import {
+    UiAppFeatureType,
+    UiAppRequestType,
+    MenuItemType
+} from '../../constants';
+import { MockClient, mockContext } from '../../utils/testUtils';
 
 import { DDDashboardCogMenuClient } from './dashboard-cog-menu';
 

--- a/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
+++ b/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
@@ -32,8 +32,6 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
         ): Promise<GetDashboardCogMenuItemsResponse> => {
             await this.validateFeatureIsEnabled();
 
-            console.log('xxx sdk onRequest context cog', context);
-
             const { items } = await requestHandler(context);
 
             return {

--- a/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
+++ b/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
@@ -1,11 +1,11 @@
-import type { DDClient } from '../client/client';
-import { UiAppFeatureType, UiAppRequestType } from '../constants';
-import { DDFeatureClient } from '../shared/feature-client';
+import type { DDClient } from '../../client/client';
+import { UiAppFeatureType, UiAppRequestType } from '../../constants';
+import { DDFeatureClient } from '../../shared/feature-client';
 import type {
     GetDashboardCogMenuItemsRequest,
     GetDashboardCogMenuItemsResponse
-} from '../types';
-import { validateKey } from '../utils/utils';
+} from '../../types';
+import { validateKey } from '../../utils/utils';
 
 const emptyConfig: GetDashboardCogMenuItemsResponse = { items: [] };
 

--- a/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
+++ b/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
@@ -18,7 +18,7 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
     }
 
     /**
-     * Registers a request handler for providing context menu items dynamically
+     * Registers a request handler for providing cog menu items dynamically
      */
     onRequest(
         requestHandler: (
@@ -31,6 +31,8 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
             context: GetDashboardCogMenuItemsRequest
         ): Promise<GetDashboardCogMenuItemsResponse> => {
             await this.validateFeatureIsEnabled();
+
+            console.log('xxx sdk onRequest context cog', context);
 
             const { items } = await requestHandler(context);
 

--- a/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -48,7 +48,7 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
     async updateOptions(newOptions: WidgetOptionItem[]) {
         const { widget } = await this.client.getContext();
         if (widget?.definition) {
-            this.client.framePostClient.send(
+            return this.client.framePostClient.request(
                 UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE,
                 {
                     customWidgetKey: widget.definition.custom_widget_key,

--- a/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -1,0 +1,60 @@
+import type { DDClient } from '../../client/client';
+import { UiAppFeatureType, UiAppRequestType } from '../../constants';
+import { DDFeatureClient } from '../../shared/feature-client';
+import type {
+    GetDashboardCustomWidgetOptionsRequest,
+    GetDashboardCustomWidgetOptionsResponse
+} from '../../types';
+import { validateKey } from '../../utils/utils';
+
+const emptyConfig: GetDashboardCustomWidgetOptionsResponse = { widgets: [] };
+
+export class DDDashboardCustomWidgetClient extends DDFeatureClient {
+    constructor(client: DDClient) {
+        super(client, UiAppFeatureType.DASHBOARD_CUSTOM_WIDGET);
+
+        // initialize with an empty reponse handler
+        this.onRequest(() => emptyConfig);
+    }
+
+    /**
+     * Registers a request handler for providing context menu items dynamically
+     */
+    onRequest(
+        requestHandler: (
+            context: GetDashboardCustomWidgetOptionsRequest
+        ) =>
+            | GetDashboardCustomWidgetOptionsResponse
+            | Promise<GetDashboardCustomWidgetOptionsResponse>
+    ) {
+        this.client.framePostClient.onRequest(
+            UiAppRequestType.GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS,
+            async (
+                context: GetDashboardCustomWidgetOptionsRequest
+            ): Promise<GetDashboardCustomWidgetOptionsResponse> => {
+                await this.validateFeatureIsEnabled();
+
+                const { widgets } = await requestHandler(context);
+
+                return {
+                    widgets: widgets.filter(widget => {
+                        try {
+                            validateKey(widget);
+                        } catch (e) {
+                            this.client.logger.error(e.message);
+
+                            return false;
+                        }
+
+                        return true;
+                    })
+                };
+            }
+        );
+
+        // return an unsubscribe hook
+        return () => {
+            this.onRequest(() => emptyConfig);
+        };
+    }
+}

--- a/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -31,23 +31,17 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
             | GetDashboardCustomWidgetOptionsResponse
             | Promise<GetDashboardCustomWidgetOptionsResponse>
     ) {
-        // this.client.framePostClient.onRequest(
-        //     UiAppRequestType.GET_DASHBOARD_CUSTOM_WIDGET_ITEMS,
-        //     async (
-        //         context: GetDashboardCustomWidgetOptionsRequest
-        //     ): Promise<GetDashboardCustomWidgetOptionsResponse> => {
-        //         await this.validateFeatureIsEnabled();
-
-        //         console.log('xxx sdk onRequest context', context);
-        //         const { widgets } = await requestHandler(context);
-
-        //         return { widgets };
-        //     }
-        // );
-
         this.client.framePostClient.onRequest(
             UiAppRequestType.GET_DASHBOARD_CUSTOM_WIDGET_ITEMS,
-            async c => console.log('xxx GET_DASHBOARD_CUSTOM_WIDGET_ITEMS c', c)
+            async (
+                context: GetDashboardCustomWidgetOptionsRequest
+            ): Promise<GetDashboardCustomWidgetOptionsResponse> => {
+                await this.validateFeatureIsEnabled();
+
+                const { widgets } = await requestHandler(context);
+
+                return { widgets };
+            }
         );
 
         // return an unsubscribe hook

--- a/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -10,7 +10,6 @@ import type {
     GetDashboardCustomWidgetOptionsResponse,
     WidgetOptionItem
 } from '../../types';
-import { validateKey } from '../../utils/utils';
 
 const emptyConfig: GetDashboardCustomWidgetOptionsResponse = { widgets: [] };
 
@@ -46,19 +45,7 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
 
                 const { widgets } = await requestHandler(context);
 
-                return {
-                    widgets: widgets.filter(widget => {
-                        try {
-                            validateKey(widget);
-                        } catch (e) {
-                            this.client.logger.error(e.message);
-
-                            return false;
-                        }
-
-                        return true;
-                    })
-                };
+                return { widgets };
             }
         );
 

--- a/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -14,16 +14,11 @@ import type {
 const emptyConfig: GetDashboardCustomWidgetOptionsResponse = { widgets: [] };
 
 export class DDDashboardCustomWidgetClient extends DDFeatureClient {
-    private optionsMap: Map<string, string[]>;
     constructor(client: DDClient) {
         super(client, UiAppFeatureType.DASHBOARD_CUSTOM_WIDGET);
 
         // initialize with an empty reponse handler
         this.onRequest(() => emptyConfig);
-
-        // setup dynamic options
-        this.optionsMap = new Map();
-        this.initDynamicOptions();
     }
 
     /**
@@ -70,14 +65,5 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
                 }
             );
         }
-    }
-
-    private initDynamicOptions() {
-        this.client.framePostClient.onRequest(
-            UiAppRequestType.GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS,
-            () => {
-                return this.optionsMap;
-            }
-        );
     }
 }

--- a/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -45,18 +45,14 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
         };
     }
 
-    async updateOptions(
-        optionsToAdd: WidgetOptionItem[],
-        optionsNamesToRemove: string[] = []
-    ) {
+    async updateOptions(newOptions: WidgetOptionItem[]) {
         const { widget } = await this.client.getContext();
         if (widget?.definition) {
             this.client.framePostClient.send(
                 UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE,
                 {
                     customWidgetKey: widget.definition.custom_widget_key,
-                    optionsToAdd,
-                    optionsNamesToRemove
+                    newOptions
                 }
             );
         }

--- a/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -6,7 +6,6 @@ import {
 } from '../../constants';
 import { DDFeatureClient } from '../../shared/feature-client';
 import type {
-    GetDashboardCustomWidgetOptionsRequest,
     GetDashboardCustomWidgetOptionsResponse,
     WidgetOptionItem
 } from '../../types';
@@ -25,20 +24,16 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
      * Registers a request handler for providing custom widget items dynamically
      */
     onRequest(
-        requestHandler: (
-            context: GetDashboardCustomWidgetOptionsRequest
-        ) =>
+        requestHandler: () =>
             | GetDashboardCustomWidgetOptionsResponse
             | Promise<GetDashboardCustomWidgetOptionsResponse>
     ) {
         this.client.framePostClient.onRequest(
             UiAppRequestType.GET_DASHBOARD_CUSTOM_WIDGET_ITEMS,
-            async (
-                context: GetDashboardCustomWidgetOptionsRequest
-            ): Promise<GetDashboardCustomWidgetOptionsResponse> => {
+            async (): Promise<GetDashboardCustomWidgetOptionsResponse> => {
                 await this.validateFeatureIsEnabled();
 
-                const { widgets } = await requestHandler(context);
+                const { widgets } = await requestHandler();
 
                 return { widgets };
             }

--- a/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -22,7 +22,7 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
     }
 
     /**
-     * Registers a request handler for providing context menu items dynamically
+     * Registers a request handler for providing custom widget items dynamically
      */
     onRequest(
         requestHandler: (
@@ -31,17 +31,23 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
             | GetDashboardCustomWidgetOptionsResponse
             | Promise<GetDashboardCustomWidgetOptionsResponse>
     ) {
+        // this.client.framePostClient.onRequest(
+        //     UiAppRequestType.GET_DASHBOARD_CUSTOM_WIDGET_ITEMS,
+        //     async (
+        //         context: GetDashboardCustomWidgetOptionsRequest
+        //     ): Promise<GetDashboardCustomWidgetOptionsResponse> => {
+        //         await this.validateFeatureIsEnabled();
+
+        //         console.log('xxx sdk onRequest context', context);
+        //         const { widgets } = await requestHandler(context);
+
+        //         return { widgets };
+        //     }
+        // );
+
         this.client.framePostClient.onRequest(
             UiAppRequestType.GET_DASHBOARD_CUSTOM_WIDGET_ITEMS,
-            async (
-                context: GetDashboardCustomWidgetOptionsRequest
-            ): Promise<GetDashboardCustomWidgetOptionsResponse> => {
-                await this.validateFeatureIsEnabled();
-
-                const { widgets } = await requestHandler(context);
-
-                return { widgets };
-            }
+            async c => console.log('xxx GET_DASHBOARD_CUSTOM_WIDGET_ITEMS c', c)
         );
 
         // return an unsubscribe hook

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -3,11 +3,15 @@ import type { DDClient } from '../client/client';
 import { UiAppRequestType } from '../constants';
 import type { Timeframe } from '../types';
 
+import { DDDashboardCogMenuClient } from './dashboard-cog-menu/dashboard-cog-menu';
+
 export class DDDashboardClient {
     private readonly client: DDClient;
+    cogMenu: DDDashboardCogMenuClient;
 
     constructor(client: DDClient) {
         this.client = client;
+        this.cogMenu = new DDDashboardCogMenuClient(this.client);
     }
 
     async setCursor({ timestamp }: SetDashboardCursorRequest) {

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -4,14 +4,17 @@ import { UiAppRequestType } from '../constants';
 import type { Timeframe } from '../types';
 
 import { DDDashboardCogMenuClient } from './dashboard-cog-menu/dashboard-cog-menu';
+import { DDDashboardCustomWidgetClient } from './dashboard-custom-widget/dashboard-custom-widget';
 
 export class DDDashboardClient {
     private readonly client: DDClient;
     cogMenu: DDDashboardCogMenuClient;
+    customWidget: DDDashboardCustomWidgetClient;
 
     constructor(client: DDClient) {
         this.client = client;
         this.cogMenu = new DDDashboardCogMenuClient(this.client);
+        this.customWidget = new DDDashboardCustomWidgetClient(this.client);
     }
 
     async setCursor({ timestamp }: SetDashboardCursorRequest) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,11 +222,6 @@ export interface AuthStateOptions extends ParentAuthStateOptions {
         | boolean;
 }
 
-export type GetDashboardCustomWidgetOptionsRequest = RequireKeys<
-    FeatureContext,
-    'dashboard' | 'widget'
->;
-
 interface WidgetOptionEnum {
     label: string;
     value: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,12 +227,18 @@ export type GetDashboardCustomWidgetOptionsRequest = RequireKeys<
     'dashboard' | 'widget'
 >;
 
+interface WidgetOptionEnum {
+    label: string;
+    value: string;
+}
 export interface WidgetOptionItem {
     label: string;
     name: string;
     type: WidgetOptionItemType;
     default?: any;
-    enum?: string[];
+    enum?: (string | WidgetOptionEnum)[];
+    required?: boolean;
+    order?: number;
 }
 
 export interface CustomWidgetItem {

--- a/src/types.ts
+++ b/src/types.ts
@@ -241,6 +241,7 @@ export interface WidgetOptionItem {
     enum?: (string | WidgetOptionEnum)[];
     required?: boolean;
     order?: number;
+    loading?: boolean;
 }
 
 export interface CustomWidgetItem {

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,6 +233,15 @@ interface WidgetOptionItem {
     default?: any;
     enum?: string[];
 }
-export interface GetDashboardCustomWidgetOptionsResponse {
+
+export interface CustomWidgetItem {
+    name: string;
+    source: string;
+    hasTitle?: boolean;
     options: WidgetOptionItem[];
+    customWidgetKey: string;
+    icon?: string;
+}
+export interface GetDashboardCustomWidgetOptionsResponse {
+    widgets: CustomWidgetItem[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,8 @@ import type {
     ModalSize,
     ModalActionLevel,
     MenuItemType,
-    AuthStateStatus
+    AuthStateStatus,
+    WidgetOptionItemType
 } from './constants';
 import type { RequireKeys } from './utils/utils';
 
@@ -218,4 +219,20 @@ export interface AuthStateOptions extends ParentAuthStateOptions {
         | Promise<CustomAuthState | boolean>
         | CustomAuthState
         | boolean;
+}
+
+export type GetDashboardCustomWidgetOptionsRequest = RequireKeys<
+    FeatureContext,
+    'dashboard' | 'widget'
+>;
+
+interface WidgetOptionItem {
+    label: string;
+    name: string;
+    type: WidgetOptionItemType;
+    default?: any;
+    enum?: string[];
+}
+export interface GetDashboardCustomWidgetOptionsResponse {
+    options: WidgetOptionItem[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface DashboardWidgetContext {
               options?: {
                   [key: string]: any;
               };
+              custom_widget_key: string;
           }
         | any;
     layout?: any;
@@ -226,7 +227,7 @@ export type GetDashboardCustomWidgetOptionsRequest = RequireKeys<
     'dashboard' | 'widget'
 >;
 
-interface WidgetOptionItem {
+export interface WidgetOptionItem {
     label: string;
     name: string;
     type: WidgetOptionItemType;


### PR DESCRIPTION
![options](https://user-images.githubusercontent.com/1262407/116876143-f91ba400-abe9-11eb-83d2-c804c3f9f218.gif)



- Introduce a new SDK namespace for dashboard features `client.dashboard`.
- **[breaking]** Move the existing cog menu feature to the new dashboard namespace. `client. dashboardCogMenu` -> `client.dashboard.cogMenu`.
- Introduce `client.dashboard.customWidget.onRequest()` to defined custom widgets dynamically in the main controller code.
- Introduce `client.dashboard.customWidget.updateOptions()` to update custom widgets options in the widget code.
- Add the ability to make widget options `required`.
- Add an optional `label` field to widget options 
- Fix a bug where default option values were ignored