### PR TITLE
update framepost timeouts and enhance auth error handling

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -56,7 +56,8 @@ export class DDClient {
 
         this.framePostClient = new ChildClient<Context>({
             debug: FramePostClientSettings.DEBUG,
-            requestTimeout: FramePostClientSettings.CLIENT_REQUEST_TIMEOUT,
+            handshakeTimeout: FramePostClientSettings.HANDSHAKE_TIMEOUT,
+            requestTimeout: FramePostClientSettings.REQUEST_TIMEOUT,
             profile: this.debug,
             context: {
                 sdkVersion: SDK_VERSION,

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -56,7 +56,9 @@ export class DDClient {
 
         this.framePostClient = new ChildClient<Context>({
             debug: FramePostClientSettings.DEBUG,
-            handshakeTimeout: FramePostClientSettings.HANDSHAKE_TIMEOUT,
+            handshakeTimeout: FramePostClientSettings.DEBUG
+                ? FramePostClientSettings.HANDSHAKE_TIMEOUT_DEV_MODE
+                : FramePostClientSettings.HANDSHAKE_TIMEOUT,
             requestTimeout: FramePostClientSettings.REQUEST_TIMEOUT,
             profile: this.debug,
             context: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,9 +49,8 @@ export enum IFrameApiRequestMethod {
 export const FramePostClientSettings = Object.freeze({
     // 3p devs most likely dont need to see framepost debug messages
     DEBUG: false,
-    // TODO: Revisit approach; the 10s is to unblock 3p devs
-    // Must match server-side constant
-    CLIENT_REQUEST_TIMEOUT: 10000
+    HANDSHAKE_TIMEOUT: 3000,
+    REQUEST_TIMEOUT: 10000
 });
 
 // "Requests" are distinct from events in that the sdk client expects a response

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,8 +49,9 @@ export enum IFrameApiRequestMethod {
 export const FramePostClientSettings = Object.freeze({
     // 3p devs most likely dont need to see framepost debug messages
     DEBUG: false,
-    HANDSHAKE_TIMEOUT: 3000,
-    REQUEST_TIMEOUT: 10000
+    HANDSHAKE_TIMEOUT: 5000,
+    HANDSHAKE_TIMEOUT_DEV_MODE: 2000,
+    REQUEST_TIMEOUT: 20000
 });
 
 // "Requests" are distinct from events in that the sdk client expects a response

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,7 +49,7 @@ export enum IFrameApiRequestMethod {
 export const FramePostClientSettings = Object.freeze({
     // 3p devs most likely dont need to see framepost debug messages
     DEBUG: false,
-    HANDSHAKE_TIMEOUT: 5000,
+    HANDSHAKE_TIMEOUT: 10000,
     HANDSHAKE_TIMEOUT_DEV_MODE: 2000,
     REQUEST_TIMEOUT: 20000
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,7 @@ export interface ParentAuthStateOptions {
     closePopupAfterAuth?: boolean;
     retryInterval?: number;
     totalTimeout?: number;
+    requestTimeout?: number;
 }
 export interface AuthStateOptions extends ParentAuthStateOptions {
     authStateCallback: () =>


### PR DESCRIPTION
- Change default framepost timeout values:
  - handshake timeout: 10s
  - handshake timeout in dev mode: 2s
  - request timeout: 20s
- Add the ability to customize the auth provider timeout period (default is 20s)
- Add error status for auth failure due to request timeouts or non interaction with the popup:
![image](https://user-images.githubusercontent.com/1262407/116921997-c04bf100-ac22-11eb-8d68-814c6617cd60.png)
