### PR TITLE
Group dynamic options by widget id

### DIFF
--- a/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -47,11 +47,12 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
 
     async updateOptions(newOptions: WidgetOptionItem[]) {
         const { widget } = await this.client.getContext();
-        if (widget?.definition) {
+        if (widget?.definition && widget?.id) {
             return this.client.framePostClient.request(
                 UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE,
                 {
                     customWidgetKey: widget.definition.custom_widget_key,
+                    customWidgetID: widget.id,
                     newOptions
                 }
             );


### PR DESCRIPTION
Fixes a bug where multiple instances of the same widget type will have to share the options updated dynamically. 