### PR TITLE
Rename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ jobs:
                   node-version: 14.14.0
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@datadog'
+            # I'm hoping this will work as part of the publish process. We will need to monitor closely, and maybe run manually but that will require admin privledges to the datadog npm account.
+            - run: npm deprecate "@datadog/ui-apps-sdk" "@datadog/ui-apps-sdk has been renamed to "@datadog/ui-extensions-sdk, please rename accordingly. Future updates will only be published under the new name."
             - run: yarn
             - run: yarn publish
               env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
                   scope: '@datadog'
             # I'm hoping this will work as part of the publish process. We will need to monitor closely, and maybe run manually but that will require admin privledges to the datadog npm account.
             - run: npm deprecate "@datadog/ui-apps-sdk" "@datadog/ui-apps-sdk has been renamed to "@datadog/ui-extensions-sdk, please rename accordingly. Future updates will only be published under the new name."
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
             - run: yarn
             - run: yarn publish
               env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,6 @@ jobs:
                   node-version: 14.14.0
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@datadog'
-            # I'm hoping this will work as part of the publish process. We will need to monitor closely, and maybe run manually but that will require admin privledges to the datadog npm account.
-            - run: npm deprecate "@datadog/ui-apps-sdk" "@datadog/ui-apps-sdk has been renamed to "@datadog/ui-extensions-sdk, please rename accordingly. Future updates will only be published under the new name."
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
             - run: yarn
             - run: yarn publish
               env:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# DataDog UI Apps SDK
+# DataDog UI Extensions SDK
 
-This packages provides a javascript SDK for DataDog UI Apps. It is under active development and is subject to breaking changes at any time.
+This packages provides a javascript SDK for DataDog UI Extensions. It is under active development and is subject to breaking changes at any time.

--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@
     <body>
         <div id="wrapper">
             Bundle is served at
-            <a href="http://localhost:8080/dist/ui-apps-sdk.min.js"
-                >http://localhost:8080/dist/ui-apps-sdk.min.js</a
+            <a href="http://localhost:8080/dist/ui-extensions-sdk.min.js"
+                >http://localhost:8080/dist/ui-extensions-sdk.min.js</a
             >
         </div>
 
-        <script src="dist/ui-apps-sdk.min.js"></script>
+        <script src="dist/ui-extensions-sdk.min.js"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-    "name": "@datadog/ui-apps-sdk",
-    "version": "0.17.0",
-    "description": "Datadog UI Apps - Official JavaScript SDK ",
-    "homepage": "https://github.com/DataDog/ui_apps_sdk",
+    "name": "@datadog/ui-extensions-sdk",
+    "version": "0.18.0",
+    "description": "Datadog UI Extensions - Official JavaScript SDK ",
+    "homepage": "https://github.com/DataDog/ui-extensions-sdk",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/DataDog/ui_apps_sdk.git"
+        "url": "git+https://github.com/DataDog/ui-extensions-sdk.git"
     },
-    "main": "dist/ui-apps-sdk.min.js",
+    "main": "dist/ui-extensions-sdk.min.js",
     "types": "dist/index.d.ts",
     "scripts": {
         "build": "webpack --mode production",

--- a/sandbox/child/index.html
+++ b/sandbox/child/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Datadog UI Apps SDK Sandbox: Child</title>
+        <title>Datadog UI Extensions SDK Sandbox: Child</title>
     </head>
 
     <body>
-        <h4>Datadog UI Apps SDK Sandbox: Child</h4>
+        <h4>Datadog UI Extensions SDK Sandbox: Child</h4>
         <div id="target">Link to public dashboard:&nbsp</div>
-        <script src="dist/ui-apps-sdk.min.js"></script>
+        <script src="dist/ui-extensions-sdk.min.js"></script>
         <script>
             const client = DD_SDK.init({ debug: true }, context => {
                 console.log('Received app context', context);

--- a/sandbox/parent/index.html
+++ b/sandbox/parent/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Datadog Ui Apps SDK Sandbox: Parent</title>
+        <title>Datadog Ui Extensions SDK Sandbox: Parent</title>
     </head>
 
     <body>
-        <h1>Datadog Ui Apps SDK Sandbox: Parent</h1>
+        <h1>Datadog Ui Extensions SDK Sandbox: Parent</h1>
         <iframe
             id="frame"
             src="http://localhost:8001"

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -1,4 +1,4 @@
-import { UiAppRequestType } from '../constants';
+import { RequestType } from '../constants';
 import { MockClient } from '../utils/testUtils';
 
 import { DDAPIClient } from './api';
@@ -24,7 +24,7 @@ describe('api', () => {
         });
 
         expect(client.framePostClient.request).toBeCalledWith(
-            UiAppRequestType.API_REQUEST,
+            RequestType.API_REQUEST,
             {
                 method: 'GET',
                 resource: '/test/endpoint',
@@ -41,7 +41,7 @@ describe('api', () => {
         apiClient.post('/test/endpoint', 'data');
 
         expect(client.framePostClient.request).toBeCalledWith(
-            UiAppRequestType.API_REQUEST,
+            RequestType.API_REQUEST,
             {
                 method: 'POST',
                 resource: '/test/endpoint',
@@ -56,7 +56,7 @@ describe('api', () => {
         apiClient.put('/test/endpoint', 'data');
 
         expect(client.framePostClient.request).toBeCalledWith(
-            UiAppRequestType.API_REQUEST,
+            RequestType.API_REQUEST,
             {
                 method: 'PUT',
                 resource: '/test/endpoint',
@@ -71,7 +71,7 @@ describe('api', () => {
         apiClient.patch('/test/endpoint', 'data');
 
         expect(client.framePostClient.request).toBeCalledWith(
-            UiAppRequestType.API_REQUEST,
+            RequestType.API_REQUEST,
             {
                 method: 'PATCH',
                 resource: '/test/endpoint',
@@ -86,7 +86,7 @@ describe('api', () => {
         apiClient.delete('/test/endpoint');
 
         expect(client.framePostClient.request).toBeCalledWith(
-            UiAppRequestType.API_REQUEST,
+            RequestType.API_REQUEST,
             {
                 method: 'DELETE',
                 resource: '/test/endpoint',

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,5 @@
 import type { DDClient } from '../client/client';
-import { UiAppRequestType } from '../constants';
+import { RequestType } from '../constants';
 import type { ApiRequest, ApiRequestOptions } from '../types';
 
 export class DDAPIClient {
@@ -19,7 +19,7 @@ export class DDAPIClient {
         }: ApiRequestOptions<Q>
     ): Promise<R> {
         return this.client.framePostClient.request<ApiRequest<Q>, R>(
-            UiAppRequestType.API_REQUEST,
+            RequestType.API_REQUEST,
             {
                 resource,
                 method,
@@ -94,7 +94,7 @@ export class DDAPIClient {
 
     async clearCredentials() {
         return this.client.framePostClient.request(
-            UiAppRequestType.CLEAR_OAUTH_CREDENTIALS
+            RequestType.CLEAR_OAUTH_CREDENTIALS
         );
     }
 }

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,5 +1,5 @@
 import type { DDClient } from '../client/client';
-import { UiAppRequestType } from '../constants';
+import { RequestType } from '../constants';
 import { AuthState, AuthStateOptions } from '../types';
 
 const defaultAuthState: Required<AuthState> = {
@@ -19,7 +19,7 @@ export class DDAuthClient {
         }
 
         this.client.framePostClient.onRequest(
-            UiAppRequestType.CHECK_AUTH_STATE,
+            RequestType.CHECK_AUTH_STATE,
             this.checkAuthState.bind(this)
         );
     }
@@ -38,18 +38,16 @@ export class DDAuthClient {
 
     async getAuthState(): Promise<AuthState> {
         await this.client.getContext();
-        return this.client.framePostClient.request(
-            UiAppRequestType.GET_AUTH_STATE,
-            { forceUpdate: false }
-        );
+        return this.client.framePostClient.request(RequestType.GET_AUTH_STATE, {
+            forceUpdate: false
+        });
     }
 
     async updateAuthState() {
         await this.client.getContext();
-        return this.client.framePostClient.request(
-            UiAppRequestType.GET_AUTH_STATE,
-            { forceUpdate: true }
-        );
+        return this.client.framePostClient.request(RequestType.GET_AUTH_STATE, {
+            forceUpdate: true
+        });
     }
 }
 

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1,6 +1,6 @@
 import { init } from '..';
 
-import { UiAppEventType } from '../constants';
+import { EventType } from '../constants';
 import { MockFramePostChildClient, mockContext } from '../utils/testUtils';
 
 import { DDClient } from './client';
@@ -43,7 +43,7 @@ describe('client.getContext()', () => {
 
         mockClient.init();
 
-        mockClient.mockEvent(UiAppEventType.CONTEXT_CHANGE, {
+        mockClient.mockEvent(EventType.CONTEXT_CHANGE, {
             data: 'new context'
         });
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -2,7 +2,7 @@ import { ChildClient } from '@datadog/framepost';
 
 import { DDAPIClient } from '../api/api';
 import { DDAuthClient } from '../auth/auth';
-import { FramePostClientSettings, UiAppEventType, Host } from '../constants';
+import { FramePostClientSettings, EventType, Host } from '../constants';
 import { DDDashboardClient } from '../dashboard/dashboard';
 import { DDEventsClient } from '../events/events';
 import { DDLocationClient } from '../location/location';
@@ -80,7 +80,7 @@ export class DDClient {
         this.secrets = new DDSecretsClient(this);
         this.widgetContextMenu = new DDWidgetContextMenuClient(this);
 
-        this.events.on(UiAppEventType.CONTEXT_CHANGE, newContext => {
+        this.events.on(EventType.CONTEXT_CHANGE, newContext => {
             this.context = newContext;
 
             this.syncDebugMode(this.context);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ export enum Host {
     STAGE = 'https://dd.datad0g.com/'
 }
 
-export enum UiAppFeatureType {
+export enum FeatureType {
     DASHBOARD_COG_MENU = 'dashboard_cog_menu',
     DASHBOARD_CUSTOM_WIDGET = 'dashboard_custom_widget',
     MODALS = 'modals',
@@ -11,7 +11,7 @@ export enum UiAppFeatureType {
     WIDGET_CONTEXT_MENU = 'widget_context_menu'
 }
 
-export enum UiAppEventType {
+export enum EventType {
     // General
     CUSTOM_EVENT = 'custom_event',
     CONTEXT_CHANGE = 'context_change',
@@ -51,7 +51,7 @@ export const FramePostClientSettings = Object.freeze({
 // "Requests" are distinct from events in that the sdk client expects a response
 // from the frameManager, or vice-versa. This is useful when the child frames
 // ask the parent frames to perform an operation.
-export enum UiAppRequestType {
+export enum RequestType {
     // API
     API_REQUEST = 'api_request',
 
@@ -96,11 +96,11 @@ export enum UiAppRequestType {
 }
 
 // These event types are always allowed, regardless of what features have been enabled
-export const enabledEvents = new Set<UiAppEventType>([
-    UiAppEventType.CUSTOM_EVENT,
-    UiAppEventType.CONTEXT_CHANGE,
-    UiAppEventType.AUTH_STATE_CHANGE,
-    UiAppEventType.API_ACCESS_CHANGE
+export const enabledEvents = new Set<EventType>([
+    EventType.CUSTOM_EVENT,
+    EventType.CONTEXT_CHANGE,
+    EventType.AUTH_STATE_CHANGE,
+    EventType.API_ACCESS_CHANGE
 ]);
 
 export enum ModalSize {

--- a/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.test.ts
+++ b/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.test.ts
@@ -1,8 +1,4 @@
-import {
-    UiAppFeatureType,
-    UiAppRequestType,
-    MenuItemType
-} from '../../constants';
+import { FeatureType, RequestType, MenuItemType } from '../../constants';
 import { MockClient, mockContext } from '../../utils/testUtils';
 
 import { DDDashboardCogMenuClient } from './dashboard-cog-menu';
@@ -21,12 +17,12 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.DASHBOARD_COG_MENU]
+                features: [FeatureType.DASHBOARD_COG_MENU]
             }
         });
 
         const response = await client.framePostClient.mockRequest(
-            UiAppRequestType.GET_DASHBOARD_COG_MENU_ITEMS,
+            RequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             'data'
         );
 
@@ -38,7 +34,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.DASHBOARD_COG_MENU]
+                features: [FeatureType.DASHBOARD_COG_MENU]
             }
         });
 
@@ -58,7 +54,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
         cogMenuClient.onRequest(handler);
 
         const response = await client.framePostClient.mockRequest(
-            UiAppRequestType.GET_DASHBOARD_COG_MENU_ITEMS,
+            RequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             'data'
         );
 
@@ -83,7 +79,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.DASHBOARD_COG_MENU]
+                features: [FeatureType.DASHBOARD_COG_MENU]
             }
         });
 
@@ -103,7 +99,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
         cogMenuClient.onRequest(handler);
 
         const response = await client.framePostClient.mockRequest(
-            UiAppRequestType.GET_DASHBOARD_COG_MENU_ITEMS,
+            RequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             'data'
         );
 
@@ -121,7 +117,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.DASHBOARD_COG_MENU]
+                features: [FeatureType.DASHBOARD_COG_MENU]
             }
         });
 
@@ -143,7 +139,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
         unsubscribe();
 
         const response = await client.framePostClient.mockRequest(
-            UiAppRequestType.GET_DASHBOARD_COG_MENU_ITEMS,
+            RequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             'data'
         );
 

--- a/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
+++ b/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
@@ -1,5 +1,5 @@
 import type { DDClient } from '../../client/client';
-import { UiAppFeatureType, UiAppRequestType } from '../../constants';
+import { FeatureType, RequestType } from '../../constants';
 import { DDFeatureClient } from '../../shared/feature-client';
 import type {
     GetDashboardCogMenuItemsRequest,
@@ -11,7 +11,7 @@ const emptyConfig: GetDashboardCogMenuItemsResponse = { items: [] };
 
 export class DDDashboardCogMenuClient extends DDFeatureClient {
     constructor(client: DDClient) {
-        super(client, UiAppFeatureType.DASHBOARD_COG_MENU);
+        super(client, FeatureType.DASHBOARD_COG_MENU);
 
         // initialize with an empty reponse handler
         this.onRequest(() => emptyConfig);
@@ -50,7 +50,7 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
         };
 
         this.client.framePostClient.onRequest(
-            UiAppRequestType.GET_DASHBOARD_COG_MENU_ITEMS,
+            RequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             wrappedHandler
         );
 

--- a/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -1,18 +1,18 @@
 import type { DDClient } from '../../client/client';
-import { UiAppEventType, UiAppFeatureType } from '../../constants';
+import { EventType, FeatureType } from '../../constants';
 import { DDFeatureClient } from '../../shared/feature-client';
 import type { WidgetOptionItem } from '../../types';
 
 export class DDDashboardCustomWidgetClient extends DDFeatureClient {
     constructor(client: DDClient) {
-        super(client, UiAppFeatureType.DASHBOARD_CUSTOM_WIDGET);
+        super(client, FeatureType.DASHBOARD_CUSTOM_WIDGET);
     }
 
     async updateOptions(newOptions: WidgetOptionItem[]) {
         const { widget } = await this.client.getContext();
         if (widget?.definition && widget?.id) {
             return this.client.framePostClient.request(
-                UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE,
+                EventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE,
                 {
                     customWidgetKey: widget.definition.custom_widget_key,
                     customWidgetID: widget.id,

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -1,6 +1,6 @@
 // Actions are UiAppRequestType requests that are sent from Datadog to the parent dashboard
 import type { DDClient } from '../client/client';
-import { UiAppRequestType } from '../constants';
+import { RequestType } from '../constants';
 import type { Timeframe } from '../types';
 
 import { DDDashboardCogMenuClient } from './dashboard-cog-menu/dashboard-cog-menu';
@@ -19,7 +19,7 @@ export class DDDashboardClient {
 
     async setCursor({ timestamp }: SetDashboardCursorRequest) {
         return this.client.framePostClient.request<SetDashboardCursorRequest>(
-            UiAppRequestType.SET_DASHBOARD_CURSOR,
+            RequestType.SET_DASHBOARD_CURSOR,
             {
                 timestamp
             }
@@ -29,7 +29,7 @@ export class DDDashboardClient {
     async setTimeframe({ timeframe }: SetDashboardTimeframeRequest) {
         return this.client.framePostClient.request<
             SetDashboardTimeframeRequest
-        >(UiAppRequestType.SET_DASHBOARD_TIMEFRAME, {
+        >(RequestType.SET_DASHBOARD_TIMEFRAME, {
             timeframe
         });
     }

--- a/src/events/events.test.ts
+++ b/src/events/events.test.ts
@@ -1,4 +1,4 @@
-import { UiAppEventType, UiAppRequestType } from '../constants';
+import { EventType, RequestType } from '../constants';
 import { MockClient, mockContext, flushPromises } from '../utils/testUtils';
 
 import { DDEventsClient } from './events';
@@ -16,13 +16,13 @@ describe('events.on()', () => {
         const callback1 = jest.fn();
         const callback2 = jest.fn();
 
-        eventsClient.on(UiAppEventType.DASHBOARD_COG_MENU_CLICK, callback1);
-        eventsClient.on(UiAppEventType.DASHBOARD_COG_MENU_CLICK, callback2);
+        eventsClient.on(EventType.DASHBOARD_COG_MENU_CLICK, callback1);
+        eventsClient.on(EventType.DASHBOARD_COG_MENU_CLICK, callback2);
 
         mockClient.framePostClient.init();
 
         mockClient.framePostClient.mockEvent(
-            UiAppEventType.DASHBOARD_COG_MENU_CLICK,
+            EventType.DASHBOARD_COG_MENU_CLICK,
             {
                 id: 'dashboardid',
                 shareToken: 'https://www.google.com'
@@ -46,9 +46,9 @@ describe('events.on()', () => {
         const callback1 = jest.fn();
         const callback2 = jest.fn();
 
-        eventsClient.on(UiAppEventType.DASHBOARD_COG_MENU_CLICK, callback1);
+        eventsClient.on(EventType.DASHBOARD_COG_MENU_CLICK, callback1);
         const unsubscribe = eventsClient.on(
-            UiAppEventType.DASHBOARD_COG_MENU_CLICK,
+            EventType.DASHBOARD_COG_MENU_CLICK,
             callback2
         );
 
@@ -57,7 +57,7 @@ describe('events.on()', () => {
         mockClient.framePostClient.init();
 
         mockClient.framePostClient.mockEvent(
-            UiAppEventType.DASHBOARD_COG_MENU_CLICK,
+            EventType.DASHBOARD_COG_MENU_CLICK,
             {
                 id: 'dashboardid',
                 shareToken: 'https://www.google.com'
@@ -77,7 +77,7 @@ describe('events.on()', () => {
             .mockImplementation(() => {});
 
         eventsClient.on(
-            UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
+            EventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
             () => {}
         );
 
@@ -90,7 +90,7 @@ describe('events.on()', () => {
         });
 
         mockClient.framePostClient.mockEvent(
-            UiAppEventType.DASHBOARD_COG_MENU_CLICK,
+            EventType.DASHBOARD_COG_MENU_CLICK,
             {
                 id: 'dashboardid',
                 shareToken: 'https://www.google.com'
@@ -123,13 +123,10 @@ describe('events.broadcast()', () => {
             frameUrls: ['https://domain.com/path/to/frame.html']
         });
 
-        expect(requestMock).toHaveBeenCalledWith(
-            UiAppRequestType.EVENT_BROADCAST,
-            {
-                eventType: 'my_event',
-                data: 'data'
-            }
-        );
+        expect(requestMock).toHaveBeenCalledWith(RequestType.EVENT_BROADCAST, {
+            eventType: 'my_event',
+            data: 'data'
+        });
     });
 });
 
@@ -143,7 +140,7 @@ describe('events.onCustom()', () => {
 
         mockClient.framePostClient.init();
 
-        mockClient.framePostClient.mockEvent(UiAppEventType.CUSTOM_EVENT, {
+        mockClient.framePostClient.mockEvent(EventType.CUSTOM_EVENT, {
             eventType: 'my_event',
             data: {
                 id: 'dashboardid',
@@ -173,7 +170,7 @@ describe('events.onCustom()', () => {
 
         mockClient.framePostClient.init();
 
-        mockClient.framePostClient.mockEvent(UiAppEventType.CUSTOM_EVENT, {
+        mockClient.framePostClient.mockEvent(EventType.CUSTOM_EVENT, {
             eventType: 'my_event',
             data: {
                 id: 'dashboardid',

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,5 +1,5 @@
 import type { DDClient } from '../client/client';
-import { UiAppEventType, UiAppRequestType } from '../constants';
+import { EventType, RequestType } from '../constants';
 import type {
     Context,
     EventHandler,
@@ -17,29 +17,29 @@ import { isEventEnabled } from '../utils/utils';
 // This interface mapping provides types for event handlers subscribed to with `client.events.on`
 interface DDEventDataTypes {
     // General
-    [UiAppEventType.CUSTOM_EVENT]: CustomEventPayload<any>;
-    [UiAppEventType.CONTEXT_CHANGE]: Context;
-    [UiAppEventType.DASHBOARD_COG_MENU_CLICK]: DashboardCogMenuClickData;
-    [UiAppEventType.WIDGET_CONTEXT_MENU_CLICK]: WidgetContextMenuClickData;
-    [UiAppEventType.MODAL_CLOSE]: ModalDefinition;
-    [UiAppEventType.MODAL_CANCEL]: ModalDefinition;
-    [UiAppEventType.MODAL_ACTION]: ModalDefinition;
-    [UiAppEventType.SIDE_PANEL_CLOSE]: SidePanelDefinition;
-    [UiAppEventType.DASHBOARD_TIMEFRAME_CHANGE]: Timeframe;
-    [UiAppEventType.DASHBOARD_CURSOR_CHANGE]: number | null;
-    [UiAppEventType.DASHBOARD_TEMPLATE_VAR_CHANGE]: TemplateVariableValue[];
-    [UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE]: {
+    [EventType.CUSTOM_EVENT]: CustomEventPayload<any>;
+    [EventType.CONTEXT_CHANGE]: Context;
+    [EventType.DASHBOARD_COG_MENU_CLICK]: DashboardCogMenuClickData;
+    [EventType.WIDGET_CONTEXT_MENU_CLICK]: WidgetContextMenuClickData;
+    [EventType.MODAL_CLOSE]: ModalDefinition;
+    [EventType.MODAL_CANCEL]: ModalDefinition;
+    [EventType.MODAL_ACTION]: ModalDefinition;
+    [EventType.SIDE_PANEL_CLOSE]: SidePanelDefinition;
+    [EventType.DASHBOARD_TIMEFRAME_CHANGE]: Timeframe;
+    [EventType.DASHBOARD_CURSOR_CHANGE]: number | null;
+    [EventType.DASHBOARD_TEMPLATE_VAR_CHANGE]: TemplateVariableValue[];
+    [EventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE]: {
         [key: string]: any;
     };
 
     // Modals
-    [UiAppEventType.MODAL_CLOSE]: ModalDefinition;
-    [UiAppEventType.MODAL_CANCEL]: ModalDefinition;
-    [UiAppEventType.MODAL_ACTION]: ModalDefinition;
+    [EventType.MODAL_CLOSE]: ModalDefinition;
+    [EventType.MODAL_CANCEL]: ModalDefinition;
+    [EventType.MODAL_ACTION]: ModalDefinition;
 
     // Auth
-    [UiAppEventType.AUTH_STATE_CHANGE]: AuthState;
-    [UiAppEventType.API_ACCESS_CHANGE]: APIAccessChangeEvent;
+    [EventType.AUTH_STATE_CHANGE]: AuthState;
+    [EventType.API_ACCESS_CHANGE]: APIAccessChangeEvent;
 }
 
 export class DDEventsClient {
@@ -97,7 +97,7 @@ export class DDEventsClient {
                 handler(payload.data);
             }
         };
-        return this.on(UiAppEventType.CUSTOM_EVENT, wrappedHandler);
+        return this.on(EventType.CUSTOM_EVENT, wrappedHandler);
     }
 
     /**
@@ -108,7 +108,7 @@ export class DDEventsClient {
         return this.client.framePostClient.request<
             CustomEventPayload<T>,
             undefined
-        >(UiAppRequestType.EVENT_BROADCAST, {
+        >(RequestType.EVENT_BROADCAST, {
             eventType,
             data
         });

--- a/src/features/dashboard-cog-menu.ts
+++ b/src/features/dashboard-cog-menu.ts
@@ -1,7 +1,7 @@
-import { UiAppFeatureType, UiAppEventType } from '../constants';
-import { UiAppFeature } from '../types';
+import { FeatureType, EventType } from '../constants';
+import { Feature } from '../types';
 
-export const dashboardCogMenu: UiAppFeature = {
-    type: UiAppFeatureType.DASHBOARD_COG_MENU,
-    events: [UiAppEventType.DASHBOARD_COG_MENU_CLICK]
+export const dashboardCogMenu: Feature = {
+    type: FeatureType.DASHBOARD_COG_MENU,
+    events: [EventType.DASHBOARD_COG_MENU_CLICK]
 };

--- a/src/features/dashboard-custom-widget.ts
+++ b/src/features/dashboard-custom-widget.ts
@@ -1,12 +1,12 @@
-import { UiAppFeatureType, UiAppEventType } from '../constants';
-import { UiAppFeature } from '../types';
+import { FeatureType, EventType } from '../constants';
+import { Feature } from '../types';
 
-export const dashboardCustomWidget: UiAppFeature = {
-    type: UiAppFeatureType.DASHBOARD_CUSTOM_WIDGET,
+export const dashboardCustomWidget: Feature = {
+    type: FeatureType.DASHBOARD_CUSTOM_WIDGET,
     events: [
-        UiAppEventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
-        UiAppEventType.DASHBOARD_TEMPLATE_VAR_CHANGE,
-        UiAppEventType.DASHBOARD_TIMEFRAME_CHANGE,
-        UiAppEventType.DASHBOARD_CURSOR_CHANGE
+        EventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
+        EventType.DASHBOARD_TEMPLATE_VAR_CHANGE,
+        EventType.DASHBOARD_TIMEFRAME_CHANGE,
+        EventType.DASHBOARD_CURSOR_CHANGE
     ]
 };

--- a/src/features/modals.ts
+++ b/src/features/modals.ts
@@ -1,11 +1,11 @@
-import { UiAppFeatureType, UiAppEventType } from '../constants';
-import { UiAppFeature } from '../types';
+import { FeatureType, EventType } from '../constants';
+import { Feature } from '../types';
 
-export const modals: UiAppFeature = {
-    type: UiAppFeatureType.MODALS,
+export const modals: Feature = {
+    type: FeatureType.MODALS,
     events: [
-        UiAppEventType.MODAL_CLOSE,
-        UiAppEventType.MODAL_CANCEL,
-        UiAppEventType.MODAL_ACTION
+        EventType.MODAL_CLOSE,
+        EventType.MODAL_CANCEL,
+        EventType.MODAL_ACTION
     ]
 };

--- a/src/features/side-panels.ts
+++ b/src/features/side-panels.ts
@@ -1,7 +1,7 @@
-import { UiAppFeatureType, UiAppEventType } from '../constants';
-import { UiAppFeature } from '../types';
+import { FeatureType, EventType } from '../constants';
+import { Feature } from '../types';
 
-export const sidePanels: UiAppFeature = {
-    type: UiAppFeatureType.SIDE_PANELS,
-    events: [UiAppEventType.SIDE_PANEL_CLOSE]
+export const sidePanels: Feature = {
+    type: FeatureType.SIDE_PANELS,
+    events: [EventType.SIDE_PANEL_CLOSE]
 };

--- a/src/features/widget-context-menu.ts
+++ b/src/features/widget-context-menu.ts
@@ -1,7 +1,7 @@
-import { UiAppFeatureType, UiAppEventType } from '../constants';
-import { UiAppFeature } from '../types';
+import { FeatureType, EventType } from '../constants';
+import { Feature } from '../types';
 
-export const widgetContextMenu: UiAppFeature = {
-    type: UiAppFeatureType.WIDGET_CONTEXT_MENU,
-    events: [UiAppEventType.WIDGET_CONTEXT_MENU_CLICK]
+export const widgetContextMenu: Feature = {
+    type: FeatureType.WIDGET_CONTEXT_MENU,
+    events: [EventType.WIDGET_CONTEXT_MENU_CLICK]
 };

--- a/src/location/location.ts
+++ b/src/location/location.ts
@@ -1,5 +1,5 @@
 import type { DDClient } from '../client/client';
-import { UiAppRequestType } from '../constants';
+import { RequestType } from '../constants';
 
 export class DDLocationClient {
     private readonly client: DDClient;
@@ -10,7 +10,7 @@ export class DDLocationClient {
 
     async goTo(url: string) {
         return this.client.framePostClient.request<NavigateTopRequest>(
-            UiAppRequestType.NAVIGATE_TOP,
+            RequestType.NAVIGATE_TOP,
             {
                 url
             }

--- a/src/modal/modal.test.ts
+++ b/src/modal/modal.test.ts
@@ -1,4 +1,4 @@
-import { UiAppFeatureType, UiAppRequestType } from '../constants';
+import { FeatureType, RequestType } from '../constants';
 import { MockClient, mockContext } from '../utils/testUtils';
 
 import { DDModalClient } from './modal';
@@ -17,7 +17,7 @@ describe('modal.open()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.MODALS]
+                features: [FeatureType.MODALS]
             }
         });
         const requestMock = jest
@@ -31,7 +31,7 @@ describe('modal.open()', () => {
 
         expect(response).toEqual(null);
 
-        expect(requestMock).toHaveBeenCalledWith(UiAppRequestType.OPEN_MODAL, {
+        expect(requestMock).toHaveBeenCalledWith(RequestType.OPEN_MODAL, {
             definition: {
                 key: 'my-modal',
                 source: 'modal.html'
@@ -44,7 +44,7 @@ describe('modal.open()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.MODALS]
+                features: [FeatureType.MODALS]
             }
         });
 
@@ -86,7 +86,7 @@ describe('modal.close()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.MODALS]
+                features: [FeatureType.MODALS]
             }
         });
         const requestMock = jest
@@ -98,7 +98,7 @@ describe('modal.close()', () => {
         expect(response).toEqual(null);
 
         expect(requestMock).toHaveBeenCalledWith(
-            UiAppRequestType.CLOSE_MODAL,
+            RequestType.CLOSE_MODAL,
             'my-modal'
         );
     });

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -1,12 +1,12 @@
 import type { DDClient } from '../client/client';
-import { UiAppFeatureType, UiAppRequestType } from '../constants';
+import { FeatureType, RequestType } from '../constants';
 import { DDFeatureClient } from '../shared/feature-client';
 import type { ModalDefinition } from '../types';
 import { validateKey } from '../utils/utils';
 
 export class DDModalClient extends DDFeatureClient {
     constructor(client: DDClient) {
-        super(client, UiAppFeatureType.MODALS);
+        super(client, FeatureType.MODALS);
     }
 
     /**
@@ -17,12 +17,9 @@ export class DDModalClient extends DDFeatureClient {
         await this.validateFeatureIsEnabled();
 
         if (validateKey(definition)) {
-            return this.client.framePostClient.request(
-                UiAppRequestType.OPEN_MODAL,
-                {
-                    definition
-                }
-            );
+            return this.client.framePostClient.request(RequestType.OPEN_MODAL, {
+                definition
+            });
         }
     }
 
@@ -34,7 +31,7 @@ export class DDModalClient extends DDFeatureClient {
         await this.validateFeatureIsEnabled();
 
         return this.client.framePostClient.request(
-            UiAppRequestType.CLOSE_MODAL,
+            RequestType.CLOSE_MODAL,
             key
         );
     }

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -1,4 +1,4 @@
-import { UiAppRequestType } from '../constants';
+import { RequestType } from '../constants';
 import { mockContext, MockLocalStorage, MockClient } from '../utils/testUtils';
 
 import { DDSecretsClient } from './secrets';
@@ -23,7 +23,7 @@ describe('client.get', () => {
         const response = await secretsClient.get('my-secret-key');
         expect(response).toEqual(null);
         expect(requestMock).toHaveBeenCalledWith(
-            UiAppRequestType.GET_SECRET,
+            RequestType.GET_SECRET,
             'my-secret-key'
         );
     });
@@ -39,7 +39,7 @@ describe('client.set', () => {
 
         const response = await secretsClient.set('my-key', 'my-secret');
         expect(response).toEqual(null);
-        expect(requestMock).toHaveBeenCalledWith(UiAppRequestType.SET_SECRET, {
+        expect(requestMock).toHaveBeenCalledWith(RequestType.SET_SECRET, {
             key: 'my-key',
             data: 'my-secret'
         });
@@ -57,7 +57,7 @@ describe('client.remove', () => {
         const response = await secretsClient.remove('my-key');
         expect(response).toEqual(null);
         expect(requestMock).toHaveBeenCalledWith(
-            UiAppRequestType.REMOVE_SECRET_PUBLIC,
+            RequestType.REMOVE_SECRET_PUBLIC,
             'my-key'
         );
     });
@@ -86,7 +86,7 @@ describe('secrets request handlers', () => {
         client.framePostClient.init();
 
         const result = client.framePostClient.mockRequest(
-            UiAppRequestType.STORE_SECRET,
+            RequestType.STORE_SECRET,
             {
                 key,
                 secret
@@ -102,7 +102,7 @@ describe('secrets request handlers', () => {
         mockStorage.setItem(key, secret);
 
         const result = client.framePostClient.mockRequest(
-            UiAppRequestType.LOAD_SECRET,
+            RequestType.LOAD_SECRET,
             {
                 key
             }
@@ -120,7 +120,7 @@ describe('secrets request handlers', () => {
         mockStorage.setItem('another_key', 'secret_3');
 
         const result = client.framePostClient.mockRequest(
-            UiAppRequestType.LOAD_ALL_SECRETS,
+            RequestType.LOAD_ALL_SECRETS,
             {
                 prefix
             }
@@ -141,7 +141,7 @@ describe('secrets request handlers', () => {
         mockStorage.setItem(key, secret);
 
         const result = client.framePostClient.mockRequest(
-            UiAppRequestType.REMOVE_SECRET,
+            RequestType.REMOVE_SECRET,
             {
                 key
             }
@@ -160,7 +160,7 @@ describe('secrets request handlers', () => {
         mockStorage.setItem('another_key', 'secret_3');
 
         const result = client.framePostClient.mockRequest(
-            UiAppRequestType.REMOVE_ALL_SECRETS,
+            RequestType.REMOVE_ALL_SECRETS,
             {
                 prefix
             }

--- a/src/secrets/secrets.ts
+++ b/src/secrets/secrets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import type { DDClient } from '../client/client';
-import { UiAppRequestType } from '../constants';
+import { RequestType } from '../constants';
 
 const getLocalStorageKeys = () => {
     // we cannot use Obbjey.keys because it doesn't work with the mocked localStorage Object.keys(window.localStorage)
@@ -19,27 +19,27 @@ export class DDSecretsClient {
 
     private registerRequestHandlers() {
         this.client.framePostClient.onRequest(
-            UiAppRequestType.STORE_SECRET,
+            RequestType.STORE_SECRET,
             this.handleStoreSecretRequest.bind(this)
         );
 
         this.client.framePostClient.onRequest(
-            UiAppRequestType.LOAD_SECRET,
+            RequestType.LOAD_SECRET,
             this.handleLoadSecretRequest.bind(this)
         );
 
         this.client.framePostClient.onRequest(
-            UiAppRequestType.LOAD_ALL_SECRETS,
+            RequestType.LOAD_ALL_SECRETS,
             this.handleLoadAllSecretsRequest.bind(this)
         );
 
         this.client.framePostClient.onRequest(
-            UiAppRequestType.REMOVE_ALL_SECRETS,
+            RequestType.REMOVE_ALL_SECRETS,
             this.handleRemoveAllSecretsRequest.bind(this)
         );
 
         this.client.framePostClient.onRequest(
-            UiAppRequestType.REMOVE_SECRET,
+            RequestType.REMOVE_SECRET,
             this.handleRemoveSecretRequest.bind(this)
         );
     }
@@ -106,25 +106,19 @@ export class DDSecretsClient {
 
     // returns a promises that resolves with the decrypted secret for a given key
     async get(key: string) {
-        return this.client.framePostClient.request(
-            UiAppRequestType.GET_SECRET,
-            key
-        );
+        return this.client.framePostClient.request(RequestType.GET_SECRET, key);
     }
 
     async set(key: string, data: string) {
-        return this.client.framePostClient.request(
-            UiAppRequestType.SET_SECRET,
-            {
-                key,
-                data
-            }
-        );
+        return this.client.framePostClient.request(RequestType.SET_SECRET, {
+            key,
+            data
+        });
     }
 
     async remove(key: string) {
         return this.client.framePostClient.request(
-            UiAppRequestType.REMOVE_SECRET_PUBLIC,
+            RequestType.REMOVE_SECRET_PUBLIC,
             key
         );
     }

--- a/src/shared/feature-client.ts
+++ b/src/shared/feature-client.ts
@@ -1,12 +1,12 @@
 import type { DDClient } from '../client/client';
-import type { UiAppFeatureType } from '../constants';
+import type { FeatureType } from '../constants';
 import { isFeatureEnabled } from '../utils/utils';
 
 export class DDFeatureClient {
     protected readonly client: DDClient;
-    protected readonly featureType: UiAppFeatureType;
+    protected readonly featureType: FeatureType;
 
-    constructor(client: DDClient, featureType: UiAppFeatureType) {
+    constructor(client: DDClient, featureType: FeatureType) {
         this.client = client;
         this.featureType = featureType;
     }

--- a/src/side-panel/side-panel.test.ts
+++ b/src/side-panel/side-panel.test.ts
@@ -1,4 +1,4 @@
-import { UiAppFeatureType, UiAppRequestType } from '../constants';
+import { FeatureType, RequestType } from '../constants';
 import { mockContext, MockClient } from '../utils/testUtils';
 
 import { DDSidePanelClient } from './side-panel';
@@ -17,7 +17,7 @@ describe('sidePanel.open()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.SIDE_PANELS]
+                features: [FeatureType.SIDE_PANELS]
             }
         });
         const requestMock = jest
@@ -31,15 +31,12 @@ describe('sidePanel.open()', () => {
 
         expect(response).toEqual(null);
 
-        expect(requestMock).toHaveBeenCalledWith(
-            UiAppRequestType.OPEN_SIDE_PANEL,
-            {
-                definition: {
-                    key: 'my-panel',
-                    source: 'panel.html'
-                }
+        expect(requestMock).toHaveBeenCalledWith(RequestType.OPEN_SIDE_PANEL, {
+            definition: {
+                key: 'my-panel',
+                source: 'panel.html'
             }
-        );
+        });
     });
 
     test('sends an open request with definition and context to parent', async () => {
@@ -47,7 +44,7 @@ describe('sidePanel.open()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.SIDE_PANELS]
+                features: [FeatureType.SIDE_PANELS]
             }
         });
         const requestMock = jest
@@ -64,16 +61,13 @@ describe('sidePanel.open()', () => {
 
         expect(response).toEqual(null);
 
-        expect(requestMock).toHaveBeenCalledWith(
-            UiAppRequestType.OPEN_SIDE_PANEL,
-            {
-                definition: {
-                    key: 'my-panel',
-                    source: 'panel.html'
-                },
-                args: { foo: 'baar' }
-            }
-        );
+        expect(requestMock).toHaveBeenCalledWith(RequestType.OPEN_SIDE_PANEL, {
+            definition: {
+                key: 'my-panel',
+                source: 'panel.html'
+            },
+            args: { foo: 'baar' }
+        });
     });
 
     test('throws an error if definition is invalid', async () => {
@@ -81,7 +75,7 @@ describe('sidePanel.open()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.SIDE_PANELS]
+                features: [FeatureType.SIDE_PANELS]
             }
         });
 
@@ -123,7 +117,7 @@ describe('sidePanel.close()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.SIDE_PANELS]
+                features: [FeatureType.SIDE_PANELS]
             }
         });
         const requestMock = jest
@@ -135,7 +129,7 @@ describe('sidePanel.close()', () => {
         expect(response).toEqual(null);
 
         expect(requestMock).toHaveBeenCalledWith(
-            UiAppRequestType.CLOSE_SIDE_PANEL,
+            RequestType.CLOSE_SIDE_PANEL,
             'my-panel'
         );
     });

--- a/src/side-panel/side-panel.ts
+++ b/src/side-panel/side-panel.ts
@@ -1,12 +1,12 @@
 import type { DDClient } from '../client/client';
-import { UiAppFeatureType, UiAppRequestType } from '../constants';
+import { FeatureType, RequestType } from '../constants';
 import { DDFeatureClient } from '../shared/feature-client';
 import { SidePanelDefinition } from '../types';
 import { validateKey } from '../utils/utils';
 
 export class DDSidePanelClient extends DDFeatureClient {
     constructor(client: DDClient) {
-        super(client, UiAppFeatureType.SIDE_PANELS);
+        super(client, FeatureType.SIDE_PANELS);
     }
 
     /**
@@ -18,7 +18,7 @@ export class DDSidePanelClient extends DDFeatureClient {
 
         if (validateKey(definition)) {
             return this.client.framePostClient.request(
-                UiAppRequestType.OPEN_SIDE_PANEL,
+                RequestType.OPEN_SIDE_PANEL,
                 { definition, args }
             );
         }
@@ -32,7 +32,7 @@ export class DDSidePanelClient extends DDFeatureClient {
         await this.validateFeatureIsEnabled();
 
         return this.client.framePostClient.request(
-            UiAppRequestType.CLOSE_SIDE_PANEL,
+            RequestType.CLOSE_SIDE_PANEL,
             key
         );
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type {
-    UiAppFeatureType,
-    UiAppEventType,
+    FeatureType,
+    EventType,
     ModalSize,
     ModalActionLevel,
     MenuItemType,
@@ -18,7 +18,7 @@ export interface ClientOptions {
 export type EventHandler<T = any> = (data: T) => void;
 
 export interface HandleEventParams<T = any> {
-    eventType: UiAppEventType;
+    eventType: EventType;
     data: T;
 }
 
@@ -31,7 +31,7 @@ export interface AppContext {
         colorTheme: ColorTheme;
     };
     // list of enabled features
-    features: UiAppFeatureType[];
+    features: FeatureType[];
     // is app running in debug mode
     debug: boolean;
 }
@@ -102,11 +102,11 @@ export interface ClientContext {
     authStateOptions?: ParentAuthStateOptions;
 }
 
-export interface UiAppFeature {
+export interface Feature {
     /* Feature type */
-    type: UiAppFeatureType;
+    type: FeatureType;
     /* The events associated with this feature */
-    events: UiAppEventType[];
+    events: EventType[];
 }
 
 export interface IframeApiRequestOptions {

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -1,4 +1,4 @@
-import { ColorTheme, UiAppFeatureType } from '../constants';
+import { ColorTheme, FeatureType } from '../constants';
 import { Context } from '../types';
 
 import { Logger } from './logger';
@@ -42,7 +42,7 @@ export const mockContext: Context = {
             timeZone: 'America/New_York',
             colorTheme: ColorTheme.light
         },
-        features: [UiAppFeatureType.DASHBOARD_COG_MENU],
+        features: [FeatureType.DASHBOARD_COG_MENU],
         debug: true
     }
 };

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { UiAppFeatureType, UiAppEventType } from '../constants';
+import { FeatureType, EventType } from '../constants';
 import { ModalDefinition, SidePanelDefinition } from '../types';
 
 import {
@@ -43,15 +43,15 @@ describe('validateKey', () => {
 describe('feature utils', () => {
     test('isEnabled correclty tests if a feature type is in the set of enabled feature types', () => {
         expect(
-            isFeatureEnabled(UiAppFeatureType.DASHBOARD_COG_MENU, [
-                UiAppFeatureType.DASHBOARD_COG_MENU,
-                UiAppFeatureType.DASHBOARD_CUSTOM_WIDGET
+            isFeatureEnabled(FeatureType.DASHBOARD_COG_MENU, [
+                FeatureType.DASHBOARD_COG_MENU,
+                FeatureType.DASHBOARD_CUSTOM_WIDGET
             ])
         ).toBe(true);
 
         expect(
-            isFeatureEnabled(UiAppFeatureType.DASHBOARD_COG_MENU, [
-                UiAppFeatureType.DASHBOARD_CUSTOM_WIDGET
+            isFeatureEnabled(FeatureType.DASHBOARD_COG_MENU, [
+                FeatureType.DASHBOARD_CUSTOM_WIDGET
             ])
         ).toBe(false);
     });
@@ -59,31 +59,31 @@ describe('feature utils', () => {
     test('getFeatureTypesByEvent returns index of the features enabling various events', () => {
         expect(
             getFeatureTypesByEvent()
-                .get(UiAppEventType.DASHBOARD_TIMEFRAME_CHANGE)
-                ?.has(UiAppFeatureType.DASHBOARD_CUSTOM_WIDGET)
+                .get(EventType.DASHBOARD_TIMEFRAME_CHANGE)
+                ?.has(FeatureType.DASHBOARD_CUSTOM_WIDGET)
         ).toBe(true);
     });
 
     test('isEventEnabled correctly tests enablement of standard events', () => {
         expect(
-            isEventEnabled(UiAppEventType.DASHBOARD_TIMEFRAME_CHANGE, [
-                UiAppFeatureType.DASHBOARD_CUSTOM_WIDGET
+            isEventEnabled(EventType.DASHBOARD_TIMEFRAME_CHANGE, [
+                FeatureType.DASHBOARD_CUSTOM_WIDGET
             ])
         ).toBe(true);
 
         expect(
-            isEventEnabled(UiAppEventType.DASHBOARD_TIMEFRAME_CHANGE, [
-                UiAppFeatureType.DASHBOARD_COG_MENU
+            isEventEnabled(EventType.DASHBOARD_TIMEFRAME_CHANGE, [
+                FeatureType.DASHBOARD_COG_MENU
             ])
         ).toBe(false);
     });
 
     test('isEventEnabled returns true for globally enabled events', () => {
-        expect(isEventEnabled(UiAppEventType.CUSTOM_EVENT, [])).toBe(true);
+        expect(isEventEnabled(EventType.CUSTOM_EVENT, [])).toBe(true);
 
         expect(
-            isEventEnabled(UiAppEventType.CUSTOM_EVENT, [
-                UiAppFeatureType.DASHBOARD_COG_MENU
+            isEventEnabled(EventType.CUSTOM_EVENT, [
+                FeatureType.DASHBOARD_COG_MENU
             ])
         ).toBe(true);
     });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { UiAppEventType, UiAppFeatureType, enabledEvents } from '../constants';
+import { EventType, FeatureType, enabledEvents } from '../constants';
 import { features } from '../features';
 import type { DefinitionWithKey } from '../types';
 
@@ -17,19 +17,16 @@ const memoize = <T>(getter: () => T): (() => T) => {
 };
 
 export const isFeatureEnabled = (
-    feature: UiAppFeatureType,
-    enabledFeatures: UiAppFeatureType[]
+    feature: FeatureType,
+    enabledFeatures: FeatureType[]
 ): boolean => enabledFeatures.includes(feature);
 
 export const getFeatureTypesByEvent = memoize(
-    (): Map<UiAppEventType, Set<UiAppFeatureType>> => {
-        const featureTypesByEvent = new Map<
-            UiAppEventType,
-            Set<UiAppFeatureType>
-        >();
+    (): Map<EventType, Set<FeatureType>> => {
+        const featureTypesByEvent = new Map<EventType, Set<FeatureType>>();
 
         features.forEach(feature => {
-            feature.events.forEach((e: UiAppEventType) => {
+            feature.events.forEach((e: EventType) => {
                 if (!featureTypesByEvent.has(e)) {
                     featureTypesByEvent.set(e, new Set());
                 }
@@ -43,8 +40,8 @@ export const getFeatureTypesByEvent = memoize(
 );
 
 export const isEventEnabled = (
-    event: UiAppEventType,
-    enabledFeatures: UiAppFeatureType[]
+    event: EventType,
+    enabledFeatures: FeatureType[]
 ): boolean => {
     if (enabledEvents.has(event)) {
         return true;
@@ -53,7 +50,7 @@ export const isEventEnabled = (
     const featureTypesByEvent = getFeatureTypesByEvent();
 
     // get the set of features that enable this event
-    const enablingFeatures = featureTypesByEvent.get(event as UiAppEventType);
+    const enablingFeatures = featureTypesByEvent.get(event as EventType);
 
     // if no enabling feature found, event is unknown
     if (!enablingFeatures) {

--- a/src/widget-context-menu/widget-context-menu.test.ts
+++ b/src/widget-context-menu/widget-context-menu.test.ts
@@ -1,4 +1,4 @@
-import { UiAppFeatureType, UiAppRequestType, MenuItemType } from '../constants';
+import { FeatureType, RequestType, MenuItemType } from '../constants';
 import { mockContext, MockClient } from '../utils/testUtils';
 
 import { DDWidgetContextMenuClient } from './widget-context-menu';
@@ -17,12 +17,12 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.WIDGET_CONTEXT_MENU]
+                features: [FeatureType.WIDGET_CONTEXT_MENU]
             }
         });
 
         const response = await client.framePostClient.mockRequest(
-            UiAppRequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
+            RequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             'data'
         );
 
@@ -34,7 +34,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.WIDGET_CONTEXT_MENU]
+                features: [FeatureType.WIDGET_CONTEXT_MENU]
             }
         });
 
@@ -54,7 +54,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
         widgetContextMenuClient.onRequest(handler);
 
         const response = await client.framePostClient.mockRequest(
-            UiAppRequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
+            RequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             'data'
         );
 
@@ -79,7 +79,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.WIDGET_CONTEXT_MENU]
+                features: [FeatureType.WIDGET_CONTEXT_MENU]
             }
         });
 
@@ -99,7 +99,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
         widgetContextMenuClient.onRequest(handler);
 
         const response = await client.framePostClient.mockRequest(
-            UiAppRequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
+            RequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             'data'
         );
 
@@ -117,7 +117,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
             ...mockContext,
             app: {
                 ...mockContext.app,
-                features: [UiAppFeatureType.WIDGET_CONTEXT_MENU]
+                features: [FeatureType.WIDGET_CONTEXT_MENU]
             }
         });
 
@@ -139,7 +139,7 @@ describe('dashboardContextMenu.onRequestItems()', () => {
         unsubscribe();
 
         const response = await client.framePostClient.mockRequest(
-            UiAppRequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
+            RequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             'data'
         );
 

--- a/src/widget-context-menu/widget-context-menu.ts
+++ b/src/widget-context-menu/widget-context-menu.ts
@@ -1,5 +1,5 @@
 import type { DDClient } from '../client/client';
-import { UiAppFeatureType, UiAppRequestType } from '../constants';
+import { FeatureType, RequestType } from '../constants';
 import { DDFeatureClient } from '../shared/feature-client';
 import type {
     GetWidgetContextMenuItemsRequest,
@@ -11,7 +11,7 @@ const emptyConfig: GetWidgetContextMenuItemsResponse = { items: [] };
 
 export class DDWidgetContextMenuClient extends DDFeatureClient {
     constructor(client: DDClient) {
-        super(client, UiAppFeatureType.WIDGET_CONTEXT_MENU);
+        super(client, FeatureType.WIDGET_CONTEXT_MENU);
 
         // initialize with an empty reponse handler
         this.onRequest(() => emptyConfig);
@@ -50,7 +50,7 @@ export class DDWidgetContextMenuClient extends DDFeatureClient {
         };
 
         this.client.framePostClient.onRequest(
-            UiAppRequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
+            RequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             wrappedHandler
         );
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = (env, options) => {
         target: ['web', 'es5'],
         entry: './src/index.ts',
         output: {
-            filename: 'ui-apps-sdk.min.js',
+            filename: 'ui-extensions-sdk.min.js',
             path: path.resolve(__dirname, 'dist'),
             library: 'DD_SDK',
             libraryTarget: 'umd'


### PR DESCRIPTION
This is a draft of a rename PR that will merge when we also merge the new api work in web-ui. The intent is to make our new naming schema clear.

Before this merges, we will rename the repo from `ui_apps_sdk` to `ui-extensions-sdk` and the npm package from `ui-apps-sdk` to `ui-extensions-sdk`