### PR TITLE
Add optional arguments when opening modal

### DIFF
--- a/src/modal/modal.test.ts
+++ b/src/modal/modal.test.ts
@@ -39,6 +39,39 @@ describe('modal.open()', () => {
         });
     });
 
+    test('sends an open modal request with definition and args to parent', async () => {
+        client.framePostClient.init({
+            ...mockContext,
+            app: {
+                ...mockContext.app,
+                features: [FeatureType.MODALS]
+            }
+        });
+        const requestMock = jest
+            .spyOn(client.framePostClient, 'request')
+            .mockImplementation(() => null);
+
+        const response = await modalClient.open(
+            {
+                key: 'my-modal',
+                source: 'modal.html'
+            },
+            { foo: 'baar' }
+        );
+
+        expect(response).toEqual(null);
+
+        expect(requestMock).toHaveBeenCalledWith(RequestType.OPEN_MODAL, {
+            definition: {
+                key: 'my-modal',
+                source: 'modal.html'
+            },
+            args: {
+                foo: 'baar'
+            }
+        });
+    });
+
     test('throws an error if modal definition is invalid', async () => {
         client.framePostClient.init({
             ...mockContext,

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -13,12 +13,13 @@ export class DDModalClient extends DDFeatureClient {
      * Opens a modal, given a full modal definition or the key of a modal
      * definition pre-defined in the app manifest
      */
-    async open(definition: ModalDefinition) {
+    async open(definition: ModalDefinition, args?: any) {
         await this.validateFeatureIsEnabled();
 
         if (validateKey(definition)) {
             return this.client.framePostClient.request(RequestType.OPEN_MODAL, {
-                definition
+                definition,
+                args
             });
         }
     }

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -13,7 +13,7 @@ export class DDModalClient extends DDFeatureClient {
      * Opens a modal, given a full modal definition or the key of a modal
      * definition pre-defined in the app manifest
      */
-    async open(definition: ModalDefinition, args?: any) {
+    async open(definition: ModalDefinition, args?: unknown) {
         await this.validateFeatureIsEnabled();
 
         if (validateKey(definition)) {


### PR DESCRIPTION
Per request, we want modals to work more like side panels where we allow arbitrary data to be passed in when opening. This is similar to #22.

Docs PR: https://github.com/DataDog/apps/pull/13