### PR TITLE
Remove dead code

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -109,12 +109,6 @@ export interface Feature {
     events: EventType[];
 }
 
-export interface IframeApiRequestOptions {
-    params?: {
-        [key: string]: any;
-    };
-}
-
 export type ApiRequestMethod = 'GET' | 'PUT' | 'POST' | 'PATCH' | 'DELETE';
 export type ApiRequestContentType = 'json' | 'urlencoded' | 'formdata';
 


### PR DESCRIPTION
Part of the sweep to remove some `any`s from the code base, we remove this dead type.
