### PR TITLE
Make `AuthState` generic

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -25,7 +25,7 @@ const DEFAULT_OPTIONS = {
     debug: false
 };
 
-export class DDClient {
+export class DDClient<AuthStateArgs = unknown> {
     private readonly host: string;
     private context?: Context | null;
     readonly framePostClient: ChildClient<Context>;
@@ -33,15 +33,15 @@ export class DDClient {
     api: DDAPIClient;
     dashboard: DDDashboardClient;
     debug: boolean;
-    events: DDEventsClient;
+    events: DDEventsClient<AuthStateArgs>;
     location: DDLocationClient;
     modal: DDModalClient;
     sidePanel: DDSidePanelClient;
     secrets: DDSecretsClient;
     widgetContextMenu: DDWidgetContextMenuClient;
-    auth: DDAuthClient;
+    auth: DDAuthClient<AuthStateArgs>;
 
-    constructor(options: ClientOptions = {}) {
+    constructor(options: ClientOptions<AuthStateArgs> = {}) {
         this.host = options.host || DEFAULT_OPTIONS.host;
         this.debug = options.debug || DEFAULT_OPTIONS.debug;
 

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -15,7 +15,7 @@ import type {
 import { isEventEnabled } from '../utils/utils';
 
 // This interface mapping provides types for event handlers subscribed to with `client.events.on`
-interface DDEventDataTypes {
+interface DDEventDataTypes<AuthStateArgs> {
     // General
     [EventType.CUSTOM_EVENT]: CustomEventPayload<any>;
     [EventType.CONTEXT_CHANGE]: Context;
@@ -38,14 +38,14 @@ interface DDEventDataTypes {
     [EventType.MODAL_ACTION]: ModalDefinition;
 
     // Auth
-    [EventType.AUTH_STATE_CHANGE]: AuthState;
+    [EventType.AUTH_STATE_CHANGE]: AuthState<AuthStateArgs>;
     [EventType.API_ACCESS_CHANGE]: APIAccessChangeEvent;
 }
 
-export class DDEventsClient {
-    private readonly client: DDClient;
+export class DDEventsClient<AuthStateArgs = unknown> {
+    private readonly client: DDClient<AuthStateArgs>;
 
-    constructor(client: DDClient) {
+    constructor(client: DDClient<AuthStateArgs>) {
         this.client = client;
     }
 
@@ -54,9 +54,9 @@ export class DDEventsClient {
      * method. This method can be called before handshake is successful, but handlers will not execute until
      * after. Will print an error if the installed app does not have the required features to handle the event type.
      */
-    on<K extends keyof DDEventDataTypes>(
+    on<K extends keyof DDEventDataTypes<AuthStateArgs>>(
         eventType: K,
-        handler: EventHandler<DDEventDataTypes[K]>
+        handler: EventHandler<DDEventDataTypes<AuthStateArgs>[K]>
     ): () => void {
         // first, immediately subscribe
         const unsubscribe = this.client.framePostClient.on(eventType, handler);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,90 @@
+import { AuthState, EventType, init } from '.';
+
+/**
+ * `AssertEqual<Actual, Expected>` checks that `Actual` is a subtype of `Expected`,
+ * and that `Expected` is a subtype of `Actual`.
+ * If both are true,
+ * then both the types are the same.
+ *
+ * If either one is not true,
+ * we provide an explanation of the reason (along with the types for introspection).
+ */
+type AssertEqual<Actual, Expected> = Actual extends Expected
+    ? Expected extends Actual
+        ? true
+        : {
+              error: 'expected type was too restrictive';
+              actual: Actual;
+              expected: Expected;
+          }
+    : {
+          error: 'actual type was incorrect';
+          actual: Actual;
+          expected: Expected;
+      };
+
+describe('init()', () => {
+    describe('type assertions', () => {
+        // The following tests don't actually need to run.
+        // All we care about is that the `AuthStateArgs` can be inferred correctly.
+        // If it doesn't infer properly,
+        // the `AssertEqual<Actual, Expected>` type will fail to type check.
+        test('infers `unknown` if no `authProvider` is given', () => {
+            const client = init();
+
+            client.events.on(EventType.AUTH_STATE_CHANGE, authState => {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const assertion: AssertEqual<
+                    typeof authState,
+                    AuthState<unknown>
+                > = true;
+            });
+        });
+
+        test('infers `unknown` if `authStateCallback` does not return `args`', () => {
+            const client = init({
+                authProvider: {
+                    authStateCallback: () => {
+                        return {
+                            isAuthenticated: false
+                        };
+                    },
+                    url: ''
+                }
+            });
+
+            client.events.on(EventType.AUTH_STATE_CHANGE, authState => {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const assertion: AssertEqual<
+                    typeof authState,
+                    AuthState<unknown>
+                > = true;
+            });
+        });
+
+        test('propagates the `AuthStateArgs` to `AUTH_STATE_CHANGE` events', () => {
+            const client = init({
+                authProvider: {
+                    authStateCallback: () => {
+                        return {
+                            args: {
+                                foo: '',
+                                bar: false
+                            },
+                            isAuthenticated: false
+                        };
+                    },
+                    url: ''
+                }
+            });
+
+            client.events.on(EventType.AUTH_STATE_CHANGE, authState => {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const assertion: AssertEqual<
+                    typeof authState,
+                    AuthState<{ foo: string; bar: boolean }>
+                > = true;
+            });
+        });
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,10 @@ let client: DDClient;
  * Initializes a client, or returns an existing one if already initialized. User can provide an optional
  * callback to b de executed with app context data when it is sent from the parent.
  */
-export const init = (
-    options?: ClientOptions,
+export const init = <AuthStateArgs = unknown>(
+    options?: ClientOptions<AuthStateArgs>,
     callback?: (context: Context) => void
-): DDClient => {
+): DDClient<AuthStateArgs> => {
     if (!client) {
         client = new DDClient(options);
     }
@@ -21,7 +21,7 @@ export const init = (
         client.getContext().then(callback);
     }
 
-    return client;
+    return client as DDClient<AuthStateArgs>;
 };
 
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,10 +9,10 @@ import type {
 } from './constants';
 import type { RequireKeys } from './utils/utils';
 
-export interface ClientOptions {
+export interface ClientOptions<AuthStateArgs = unknown> {
     debug?: boolean;
     host?: string;
-    authProvider?: AuthStateOptions;
+    authProvider?: AuthStateOptions<AuthStateArgs>;
 }
 
 export type EventHandler<T = any> = (data: T) => void;
@@ -191,8 +191,8 @@ export type GetDashboardCogMenuItemsRequest = RequireKeys<
 export interface GetDashboardCogMenuItemsResponse
     extends MenuItemRequestResponse {}
 
-export interface AuthState {
-    args?: any;
+export interface AuthState<Args = unknown> {
+    args?: Args;
     isAuthenticated: boolean;
 }
 
@@ -219,8 +219,13 @@ export type ParentAuthStateOptions = {
     | AuthStateOptionsCloseResolution
 );
 
-export type AuthStateOptions = ParentAuthStateOptions & {
-    authStateCallback: () => Promise<AuthState | boolean> | AuthState | boolean;
+export type AuthStateOptions<
+    AuthStateArgs = unknown
+> = ParentAuthStateOptions & {
+    authStateCallback: () =>
+        | Promise<AuthState<AuthStateArgs> | boolean>
+        | AuthState<AuthStateArgs>
+        | boolean;
 };
 
 interface WidgetOptionEnum {


### PR DESCRIPTION
We make it so the `args` of the `AuthState` is now generic and can be decided when initializing the client. This should allow for greater type safety when working with the SDK client and using auth in particular.

Probably the thing to check is that we're okay with the tests added in `index.test.ts`. The reason behind them is explained a bit in the commit, but for posterity, it took a non-trivial amount of time to figure out why things weren't inferring properly, and it was because one of the `DDClient`'s didn't have its type variable properly set (it was defaulting to `DDClient<unknown>`). If we'd prefer a different way, more than happy to switch to that. But this is what I came up with.