### PR TITLE
Remove some `any`s from custom widgets

### DIFF
--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -29,7 +29,7 @@ interface DDEventDataTypes {
     [EventType.DASHBOARD_CURSOR_CHANGE]: number | null;
     [EventType.DASHBOARD_TEMPLATE_VAR_CHANGE]: TemplateVariableValue[];
     [EventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE]: {
-        [key: string]: any;
+        [key: string]: string | boolean;
     };
 
     // Modals

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export interface DashboardWidgetContext {
     definition:
         | {
               options?: {
-                  [key: string]: any;
+                  [key: string]: string | boolean;
               };
               custom_widget_key: string;
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,15 +227,26 @@ interface WidgetOptionEnum {
     label: string;
     value: string;
 }
-export interface WidgetOptionItem extends OrderedItem {
+
+export interface WidgetOptionItemBase extends OrderedItem {
     label: string;
     name: string;
-    type: WidgetOptionItemType;
-    default?: any;
-    enum?: (string | WidgetOptionEnum)[];
     required?: boolean;
     loading?: boolean;
 }
+
+export interface WidgetOptionItemBoolean extends WidgetOptionItemBase {
+    type: WidgetOptionItemType.BOOLEAN;
+    default?: boolean;
+}
+
+export interface WidgetOptionItemString extends WidgetOptionItemBase {
+    type: WidgetOptionItemType.STRING;
+    default?: string;
+    enum?: (string | WidgetOptionEnum)[];
+}
+
+export type WidgetOptionItem = WidgetOptionItemBoolean | WidgetOptionItemString;
 
 export interface CustomWidgetItem {
     name: string;


### PR DESCRIPTION
We change how we define custom widget options so they can be typed a bit stricter and remove some `any`s in the process.

Docs PR: https://github.com/DataDog/apps/pull/16