### PR TITLE
Remove more `any`s

### DIFF
--- a/src/side-panel/side-panel.ts
+++ b/src/side-panel/side-panel.ts
@@ -13,7 +13,7 @@ export class DDSidePanelClient extends DDFeatureClient {
      * Opens a side panel, given a full side panel definition or the key of a side panel
      * definition pre-defined in the app manifest
      */
-    async open(definition: SidePanelDefinition, args?: any) {
+    async open(definition: SidePanelDefinition, args?: unknown) {
         await this.validateFeatureIsEnabled();
 
         if (validateKey(definition)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,7 @@ export interface FeatureContext {
     menuItem?: MenuItemContext;
     widgetInteraction?: WidgetInteractionContext;
     // Optional arguements passed to different feature components like modal, side panel, etc
-    args?: any;
+    args?: unknown;
 }
 
 // A full context object including above feature context and additional global app context

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,9 +15,9 @@ export interface ClientOptions {
     authProvider?: AuthStateOptions;
 }
 
-export type EventHandler<T = any> = (data: T) => void;
+export type EventHandler<T = unknown> = (data: T) => void;
 
-export interface HandleEventParams<T = any> {
+export interface HandleEventParams<T = unknown> {
     eventType: EventType;
     data: T;
 }


### PR DESCRIPTION
This removes some more `any`s from the SDK. See the commit messages for explanations on why we're using `unknown` instead of generics.