### PR TITLE
Support auto sizing modal height

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -55,6 +55,22 @@ describe('client.getContext()', () => {
     });
 });
 
+describe('client.resize()', () => {
+    test('sends a `RESIZE_IFRAME` event', () => {
+        const client = new DDClient();
+
+        mockClient.send = jest.fn();
+        mockClient.init();
+
+        client.resize();
+
+        expect(mockClient.send).toHaveBeenCalledWith(EventType.RESIZE_IFRAME, {
+            height: 0,
+            width: 0
+        });
+    });
+});
+
 describe('sdk init method', () => {
     test('returns a client instance', () => {
         const client = init();

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -69,6 +69,39 @@ describe('client.resize()', () => {
             width: 0
         });
     });
+
+    test('sends the given `IFrameDimensions`', () => {
+        const client = new DDClient();
+
+        mockClient.send = jest.fn();
+        mockClient.init();
+
+        client.resize({
+            height: 123,
+            width: 456
+        });
+
+        expect(mockClient.send).toHaveBeenCalledWith(EventType.RESIZE_IFRAME, {
+            height: 123,
+            width: 456
+        });
+    });
+
+    test('can accept only height', () => {
+        const client = new DDClient();
+
+        mockClient.send = jest.fn();
+        mockClient.init();
+
+        client.resize({
+            height: 123
+        });
+
+        expect(mockClient.send).toHaveBeenCalledWith(EventType.RESIZE_IFRAME, {
+            height: 123,
+            width: 0
+        });
+    });
 });
 
 describe('sdk init method', () => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -105,10 +105,12 @@ export class DDClient<AuthStateArgs = unknown> {
     /**
      * Notify the parent that the iframe should be resized.
      *
+     * Will default any dimensions not given to the iframe's actual dimensions.
+     *
      * There's no guarantee that the parent will adjust the iframe's dimensions.
      * The parent will also sanitize the dimensions attempting to keep the iframe within the viewport.
      */
-    resize() {
+    resize(dimensions?: Partial<IFrameDimensions>) {
         const style = window.getComputedStyle(document.documentElement);
         const parsedHeight = parseFloat(style.getPropertyValue('height'));
         const parsedWidth = parseFloat(style.getPropertyValue('width'));
@@ -118,12 +120,12 @@ export class DDClient<AuthStateArgs = unknown> {
         const width = Number.isNaN(parsedWidth)
             ? document.documentElement.scrollWidth
             : parsedWidth;
-        const dimensions: IFrameDimensions = {
-            height,
-            width
+        const computedDimensions: IFrameDimensions = {
+            height: dimensions?.height ?? height,
+            width: dimensions?.width ?? width
         };
 
-        this.framePostClient.send(EventType.RESIZE_IFRAME, dimensions);
+        this.framePostClient.send(EventType.RESIZE_IFRAME, computedDimensions);
     }
 
     /**

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -98,10 +98,20 @@ export class DDClient<AuthStateArgs = unknown> {
         // Since computing the size of an iframe is hard to do correctly,
         // we listen to `'resize'` events so we can send the actual values over.
         window.addEventListener('resize', () => {
+            const style = window.getComputedStyle(document.documentElement);
+            const parsedHeight = parseFloat(style.getPropertyValue('height'));
+            const parsedWidth = parseFloat(style.getPropertyValue('width'));
+            const height = Number.isNaN(parsedHeight)
+                ? document.documentElement.scrollHeight
+                : parsedHeight;
+            const width = Number.isNaN(parsedWidth)
+                ? document.documentElement.scrollWidth
+                : parsedWidth;
             const dimensions: IFrameDimensions = {
-                height: document.documentElement.scrollHeight,
-                width: document.documentElement.scrollWidth
+                height,
+                width
             };
+
             this.framePostClient.send(EventType.RESIZE_IFRAME, dimensions);
         });
     }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -98,22 +98,32 @@ export class DDClient<AuthStateArgs = unknown> {
         // Since computing the size of an iframe is hard to do correctly,
         // we listen to `'resize'` events so we can send the actual values over.
         window.addEventListener('resize', () => {
-            const style = window.getComputedStyle(document.documentElement);
-            const parsedHeight = parseFloat(style.getPropertyValue('height'));
-            const parsedWidth = parseFloat(style.getPropertyValue('width'));
-            const height = Number.isNaN(parsedHeight)
-                ? document.documentElement.scrollHeight
-                : parsedHeight;
-            const width = Number.isNaN(parsedWidth)
-                ? document.documentElement.scrollWidth
-                : parsedWidth;
-            const dimensions: IFrameDimensions = {
-                height,
-                width
-            };
-
-            this.framePostClient.send(EventType.RESIZE_IFRAME, dimensions);
+            this.resize();
         });
+    }
+
+    /**
+     * Notify the parent that the iframe should be resized.
+     *
+     * There's no guarantee that the parent will adjust the iframe's dimensions.
+     * The parent will also sanitize the dimensions attempting to keep the iframe within the viewport.
+     */
+    resize() {
+        const style = window.getComputedStyle(document.documentElement);
+        const parsedHeight = parseFloat(style.getPropertyValue('height'));
+        const parsedWidth = parseFloat(style.getPropertyValue('width'));
+        const height = Number.isNaN(parsedHeight)
+            ? document.documentElement.scrollHeight
+            : parsedHeight;
+        const width = Number.isNaN(parsedWidth)
+            ? document.documentElement.scrollWidth
+            : parsedWidth;
+        const dimensions: IFrameDimensions = {
+            height,
+            width
+        };
+
+        this.framePostClient.send(EventType.RESIZE_IFRAME, dimensions);
     }
 
     /**

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -13,6 +13,7 @@ import type {
     Context,
     ClientContext,
     ClientOptions,
+    IFrameDimensions,
     ParentAuthStateOptions
 } from '../types';
 import { Logger } from '../utils/logger';
@@ -88,6 +89,20 @@ export class DDClient<AuthStateArgs = unknown> {
 
         this.getContext().then(context => {
             this.syncDebugMode(context);
+        });
+
+        this.registerEventListeners();
+    }
+
+    private registerEventListeners() {
+        // Since computing the size of an iframe is hard to do correctly,
+        // we listen to `'resize'` events so we can send the actual values over.
+        window.addEventListener('resize', () => {
+            const dimensions: IFrameDimensions = {
+                height: document.documentElement.scrollHeight,
+                width: document.documentElement.scrollWidth
+            };
+            this.framePostClient.send(EventType.RESIZE_IFRAME, dimensions);
         });
     }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -95,11 +95,18 @@ export class DDClient<AuthStateArgs = unknown> {
     }
 
     private registerEventListeners() {
+        const handler = () => {
+            this.resize();
+
+            // We only want to handle resizing once.
+            // If we keep this `'resize'` handler,
+            // we can get into a loop of infinitely resizing the iframe.
+            window.removeEventListener('resize', handler);
+        };
+
         // Since computing the size of an iframe is hard to do correctly,
         // we listen to `'resize'` events so we can send the actual values over.
-        window.addEventListener('resize', () => {
-            this.resize();
-        });
+        window.addEventListener('resize', handler);
     }
 
     /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export enum EventType {
     // General
     CUSTOM_EVENT = 'custom_event',
     CONTEXT_CHANGE = 'context_change',
+    RESIZE_IFRAME = 'resize_iframe',
 
     // Dashboards
     DASHBOARD_COG_MENU_CLICK = 'dashboard_cog_menu_click',

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -3,6 +3,7 @@ import { EventType, RequestType } from '../constants';
 import type {
     Context,
     EventHandler,
+    IFrameDimensions,
     Timeframe,
     TemplateVariableValue,
     ModalDefinition,
@@ -19,6 +20,7 @@ interface DDEventDataTypes<AuthStateArgs> {
     // General
     [EventType.CUSTOM_EVENT]: CustomEventPayload<any>;
     [EventType.CONTEXT_CHANGE]: Context;
+    [EventType.RESIZE_IFRAME]: IFrameDimensions;
     [EventType.DASHBOARD_COG_MENU_CLICK]: DashboardCogMenuClickData;
     [EventType.WIDGET_CONTEXT_MENU_CLICK]: WidgetContextMenuClickData;
     [EventType.MODAL_CLOSE]: ModalDefinition;

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,3 +269,8 @@ export interface APIAccessChangeEvent {
 export interface OrderedItem {
     order?: number;
 }
+
+export interface IFrameDimensions {
+    height: number;
+    width: number;
+}


### PR DESCRIPTION
We make a new event for resizing the iframe and send it over the wire whenever the iframe is resized. This allows us to set the modal height to whatever the height of the actual content is.

Docs PR: https://github.com/DataDog/apps/pull/24.