### PR TITLE
Explain the Node.js-specific documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Datadog Apps allow third party developers to extend the native functionality off
 * [Frequently Asked Questions](docs/en/faq.md)
 * [UI-Extension Design Guidelines](docs/en/ui-extensions-design-guidelines.md)
 * [Datadog API Reference](https://docs.datadoghq.com/api/latest/)
-    * Note: the TypeScript examples in the Datadog API Reference and the [`@datadog/datadog-api-client`](https://www.npmjs.com/package/@datadog/datadog-api-client) are currently Node.js-only, while Datadog Apps are browser-only. The API Reference is useful to understand the Datadog API, but the examples will need some conversion for the browser.
+    * Note: the TypeScript examples in the Datadog API Reference and the [`@datadog/datadog-api-client`](https://www.npmjs.com/package/@datadog/datadog-api-client) are currently Node.js-only, while Datadog Apps are browser-only. The API Reference is useful to understand the Datadog API, but the examples will need some conversion for the browser. 
     
-        We are working on updating the [`@datadog/datadog-api-client`](https://www.npmjs.com/package/@datadog/datadog-api-client) to work seamlessly with the [`@datadog/ui-extensions-sdk`](https://www.npmjs.com/package/@datadog/ui-extensions-sdk). In the mean-time, we recommend accessing the Datadog API with the [`@datadog/ui-extensions-sdk`](https://www.npmjs.com/package/@datadog/ui-extensions-sdk) directly.
+        We are working on updating the [`@datadog/datadog-api-client`](https://www.npmjs.com/package/@datadog/datadog-api-client) to work seamlessly with the [`@datadog/ui-extensions-sdk`](https://www.npmjs.com/package/@datadog/ui-extensions-sdk). In the mean-time, we recommend accessing the Datadog API with the [`@datadog/ui-extensions-sdk` directly](docs/en/programming-model.md#accessing-the-api-through-the-sdk).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Datadog Apps allow third party developers to extend the native functionality off
 * [Frequently Asked Questions](docs/en/faq.md)
 * [UI-Extension Design Guidelines](docs/en/ui-extensions-design-guidelines.md)
 * [Datadog API Reference](https://docs.datadoghq.com/api/latest/)
-    * Note: the TypeScript examples here and the [`@datadog/datadog-api-client`](https://www.npmjs.com/package/@datadog/datadog-api-client) are currently Node.js-only, while Datadog Apps are browser-only. The API Reference is useful to understand the Datadog API, but the examples will need some conversion for the browser. 
+    * Note: the TypeScript examples in the Datadog API Reference and the [`@datadog/datadog-api-client`](https://www.npmjs.com/package/@datadog/datadog-api-client) are currently Node.js-only, while Datadog Apps are browser-only. The API Reference is useful to understand the Datadog API, but the examples will need some conversion for the browser. 
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Datadog Apps allow third party developers to extend the native functionality off
 * [Frequently Asked Questions](docs/en/faq.md)
 * [UI-Extension Design Guidelines](docs/en/ui-extensions-design-guidelines.md)
 * [Datadog API Reference](https://docs.datadoghq.com/api/latest/)
+    * Note: the TypeScript examples here and the [`@datadog/datadog-api-client`](https://www.npmjs.com/package/@datadog/datadog-api-client) are currently Node.js-only, while Datadog Apps are browser-only. The API Reference is useful to understand the Datadog API, but the examples will need some conversion for the browser. 
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Datadog Apps allow third party developers to extend the native functionality off
 * [Frequently Asked Questions](docs/en/faq.md)
 * [UI-Extension Design Guidelines](docs/en/ui-extensions-design-guidelines.md)
 * [Datadog API Reference](https://docs.datadoghq.com/api/latest/)
-    * Note: the TypeScript examples in the Datadog API Reference and the [`@datadog/datadog-api-client`](https://www.npmjs.com/package/@datadog/datadog-api-client) are currently Node.js-only, while Datadog Apps are browser-only. The API Reference is useful to understand the Datadog API, but the examples will need some conversion for the browser. 
+    * Note: the TypeScript examples in the Datadog API Reference and the [`@datadog/datadog-api-client`](https://www.npmjs.com/package/@datadog/datadog-api-client) are currently Node.js-only, while Datadog Apps are browser-only. The API Reference is useful to understand the Datadog API, but the examples will need some conversion for the browser.
+    
+        We are working on updating the [`@datadog/datadog-api-client`](https://www.npmjs.com/package/@datadog/datadog-api-client) to work seamlessly with the [`@datadog/ui-extensions-sdk`](https://www.npmjs.com/package/@datadog/ui-extensions-sdk). In the mean-time, we recommend accessing the Datadog API with the [`@datadog/ui-extensions-sdk`](https://www.npmjs.com/package/@datadog/ui-extensions-sdk) directly.
 
 ## Examples
 


### PR DESCRIPTION
The Datadog API Reference doesn't work for Apps out of the box.

We note down that it's not a straight-shot and will take a bit of work.
Hopefully, this will be addressed by the API client becoming usable in the browser.