### PR TITLE
Fix `sentiment` example build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,7 @@ jobs:
               run: yarn
             - name: lint
               run: yarn lint
+            - name: build
+              run: yarn build
             - name: test
               run: yarn test

--- a/examples/sentiment/src/modal/index.js
+++ b/examples/sentiment/src/modal/index.js
@@ -3,7 +3,7 @@ import "./../index.css";
 import React from "react";
 import ReactDOM from "react-dom";
 
-const client = init();
+init();
 
 function Modal() {
 

--- a/examples/sentiment/src/tweets.js
+++ b/examples/sentiment/src/tweets.js
@@ -1,4 +1,4 @@
-export default {
+const tweets = {
   "tweets": [
     {
       "name": "JFrog",
@@ -348,3 +348,5 @@ export default {
     }
   ]
 }
+
+export default tweets;


### PR DESCRIPTION
While trying to put together https://github.com/DataDog/apps/pull/67, it looks like the `sentiment` example is breaking due to lint errors. Rather than continue to muddy up that PR, the fix is in this PR instead.

The actual error is in the [first commit's build](https://github.com/DataDog/apps/runs/4514539207?check_suite_focus=true).