### PR TITLE
Ignore generated `CHANGELOG.md` for  `ui-extensions-sdk`

### DIFF
--- a/packages/ui-extensions-sdk/.prettierignore
+++ b/packages/ui-extensions-sdk/.prettierignore
@@ -1,1 +1,2 @@
+CHANGELOG.md
 dist


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- `auto` generates a changelog for us, but it doesn't adhere to our formatting requirements. So, CI was failing. An example of the failure: https://github.com/DataDog/apps/runs/4538277567?check_suite_focus=true.

<!-- - Is this a bugfix or a feature? -->

## Changes

- We're going to ignore the `packages/ui-extensions-sdk/CHANGELOG.md` file for `prettier`.

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

## Change Type

<!-- Select one -->

- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- Change Type Docs https://intuit.github.io/auto/docs/generated/pr-body-labels -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/ui-extensions-sdk@0.24.2-canary.71.af2c9f5.0
  # or 
  yarn add @datadog/ui-extensions-sdk@0.24.2-canary.71.af2c9f5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
