### PR TITLE
UIAPPS-92 Fix the `--directory`

### DIFF
--- a/.changeset/funny-dolphins-lay.md
+++ b/.changeset/funny-dolphins-lay.md
@@ -1,0 +1,9 @@
+---
+'@datadog/create-app': patch
+---
+
+Default `--directory` flag to the name of the example.
+
+Instead of always defaulting to `starter-kit`,
+we default the directory to whatever the name of the example is.
+People can still override the directory by explicitly passing the `--directory` flag.


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- Jira Issue: https://datadoghq.atlassian.net/browse/UIAPPS-92

<!-- - Is this a bugfix or a feature? -->

## Changes

- We now default the `--directory` flag to the name of the example instead of always using the `starter-kit` as the default.

<!-- - If there's a UI Change: please include a screenshot. -->
<!-- - If there's not a UI Change: please remove this table. -->

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->
N.B. This is only using `npm init` and the canary release for testing. `yarn create` doesn't seem to like the tag at the end of the package.

1. [ ] Init the `random-dog` example (no explicit directory) and it should create a new `random-dog` directory:
    ```Console
    $ npm init @datadog/app@1.0.2-canary.76.47d0bf4.0 -- --example random-dog
    Creating random-dog directory
    Downloading random-dog example…
    …
    ```
1. [ ] Init the `random-dog` example in the `new-random-dog-app` directory, and it should create the correct directory:
    ```Console
    $ npm init @datadog/app@1.0.2-canary.76.47d0bf4.0 -- --directory new-random-dog-app --example 
    random-dog
    Creating new-random-dog-app directory
    Downloading random-dog example…
    ```

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

- [ ] No release is necessary.
    If you're only updating examples/documentation, this is likely what you want.
- [x] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/create-app@1.0.2-canary.76.47d0bf4.0
  # or 
  yarn add @datadog/create-app@1.0.2-canary.76.47d0bf4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
