### PR TITLE
Remove `pull_request_target` from `ci`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: Continuous Integration
 
 on:
     - push
-    - pull_request_target
 
 jobs:
     ci:


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- It seems like using the `pull_request_target` in the "Continuous Integration" workflow isn't what we want. For more motivation, see the first commit.

<!-- - Is this a bugfix or a feature? -->

## Changes

- Removes the `pull_request_target` event.

<!-- - If there's a UI Change: please include a screenshot. -->
<!-- - If there's not a UI Change: please remove this table. -->

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

- [x] No release is necessary.
    If you're only updating examples/documentation, this is likely what you want.
- [ ] All packages that need a release have a changeset.
