### PR TITLE
Full cleanup on destroy()

### DIFF
--- a/.changeset/loud-apricots-happen.md
+++ b/.changeset/loud-apricots-happen.md
@@ -1,0 +1,6 @@
+---
+'@datadog/framepost': minor
+'@datadog/ui-extensions-sdk': minor
+---
+
+Ensure full shutdown of requests on framepost client destroy. Additional errors may now be thrown from request handlers in rare side-cases. This shoult mainly not effect the SDK, but we are bumping the minor version to be safe.

--- a/.changeset/loud-apricots-happen.md
+++ b/.changeset/loud-apricots-happen.md
@@ -3,4 +3,4 @@
 '@datadog/ui-extensions-sdk': minor
 ---
 
-Ensure full shutdown of requests on framepost client destroy. Additional errors may now be thrown from request handlers in rare side-cases. This shoult mainly not effect the SDK, but we are bumping the minor version to be safe.
+Ensure full shutdown of requests on framepost client destroy. Additional errors may now be thrown from request handlers in rare side-cases. This should mainly not affect the SDK, but we are bumping the minor version to be safe.

--- a/packages/framepost/CHANGELOG.md
+++ b/packages/framepost/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @datadog/framepost
 
 ## 0.2.4
+
 ### Patch Changes
 
-- ca3c3ae: Import framepost into monorepo
+-   ca3c3ae: Import framepost into monorepo

--- a/packages/framepost/package.json
+++ b/packages/framepost/package.json
@@ -2,10 +2,11 @@
     "name": "@datadog/framepost",
     "version": "0.2.4",
     "description": "Secure parent-child iframe communication",
-    "homepage": "https://github.com/DataDog/framepost",
+    "homepage": "https://github.com/DataDog/apps/tree/master/packages/framepost",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/DataDog/framepost.git"
+        "url": "git+https://github.com/DataDog/apps.git",
+        "directory": "packages/framepost"
     },
     "main": "dist/framepost.min.js",
     "types": "dist/src/index.d.ts",

--- a/packages/framepost/sandbox/child/index.html
+++ b/packages/framepost/sandbox/child/index.html
@@ -34,6 +34,10 @@
             client.request('requestFromParent').then(data => {
                 console.log('received requested data from parent', data);
             });
+
+            try {
+                client.destroy();
+            } catch (e) {}
         </script>
     </body>
 </html>

--- a/packages/framepost/sandbox/child/index.html
+++ b/packages/framepost/sandbox/child/index.html
@@ -34,10 +34,6 @@
             client.request('requestFromParent').then(data => {
                 console.log('received requested data from parent', data);
             });
-
-            try {
-                client.destroy();
-            } catch (e) {}
         </script>
     </body>
 </html>

--- a/packages/framepost/src/child.ts
+++ b/packages/framepost/src/child.ts
@@ -45,13 +45,7 @@ export class ChildClient<C = any> extends SharedClient<C> {
     }
 
     destroy() {
-        if (this.messagePort) {
-            this.messagePort.close();
-        }
-
-        if (this.initTimer) {
-            clearTimeout(this.initTimer);
-        }
+        super.destroy();
 
         window.removeEventListener('message', this.initListener);
     }

--- a/packages/framepost/src/errors.ts
+++ b/packages/framepost/src/errors.ts
@@ -6,6 +6,13 @@ export class HandshakeTimeoutError extends Error {
     constructor() {
         super('Handshake timed out');
 
+        /**
+         * Because we are targeting es5 in complilation, instanceOf checks won't work
+         * with the resulting error types. See https://www.dannyguo.com/blog/how-to-fix-instanceof-not-working-for-custom-errors-in-typescript/
+         * TODO: Can we upgrade the compilation target? What do we need to support in iframes?
+         */
+        Object.setPrototypeOf(this, HandshakeTimeoutError.prototype);
+
         this.name = 'HandshakeTimeoutError';
     }
 }
@@ -14,6 +21,18 @@ export class RequestTimeoutError extends Error {
     constructor() {
         super('Request timed out');
 
+        Object.setPrototypeOf(this, RequestTimeoutError.prototype);
+
         this.name = 'RequestTimeoutError';
+    }
+}
+
+export class ClientDestroyedError extends Error {
+    constructor() {
+        super('Client destroyed');
+
+        Object.setPrototypeOf(this, ClientDestroyedError.prototype);
+
+        this.name = 'ClientDestroyedError';
     }
 }

--- a/packages/framepost/src/parent.ts
+++ b/packages/framepost/src/parent.ts
@@ -75,14 +75,4 @@ export class ParentClient<C = any> extends SharedClient<C> {
     protected getLogger() {
         return getLogger('parent-client', this.debug);
     }
-
-    destroy() {
-        if (this.messagePort) {
-            this.messagePort.close();
-        }
-
-        if (this.initTimer) {
-            clearTimeout(this.initTimer);
-        }
-    }
 }


### PR DESCRIPTION
* Ensure that all open timeouts are closed
* Ensure that all open requests throw a ClientDestroyError
* Ensure that open handshake promises reject with ClientDestroyedError

<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- What is the motivation / context for this change? (Text, screenshot, JIRA ticket, Github Issue)

<!-- - Is this a bugfix or a feature? -->

## Changes

- What does this change? (Link to Github Issue if applicable, e.g. #44)

<!-- - If there's a UI Change: please include a screenshot. -->
<!-- - If there's not a UI Change: please remove this table. -->

| Before | After |
| --- | --- |
| ![Before alt text](Before URL) | ![After alt text](After URL) |

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

- [ ] No release is necessary.
    If you're only updating examples/documentation, this is likely what you want.
- [x] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/framepost@0.2.5-canary.84.8284ac7.0
  npm install @datadog/ui-extensions-sdk@0.24.6-canary.84.8284ac7.0
  # or 
  yarn add @datadog/framepost@0.2.5-canary.84.8284ac7.0
  yarn add @datadog/ui-extensions-sdk@0.24.6-canary.84.8284ac7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
