### PR TITLE
UIAPPS-96 Ignore `CHANGELOG.md` in `framepost`

### DIFF
--- a/packages/framepost/.prettierignore
+++ b/packages/framepost/.prettierignore
@@ -1,1 +1,2 @@
 dist
+CHANGELOG.md


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- Jira Issue: https://datadoghq.atlassian.net/browse/UIAPPS-96

<!-- - Is this a bugfix or a feature? -->

## Changes

- We ignore the `CHANGELOG.md` file in `framepost`.

Side note, it seems like if we move most of these scripts out of the individual packages (https://datadoghq.atlassian.net/browse/UIAPPS-88) we shouldn't have to deal with this in the future.
As it is now, we can't really write an ignore once that applies to everything, due to https://github.com/prettier/prettier/issues/4081.

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

- [x] No release is necessary.
    If you're only updating examples/documentation, this is likely what you want.
- [ ] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/framepost@0.2.5-canary.85.06bae98.0
  npm install @datadog/ui-extensions-sdk@0.24.6-canary.85.06bae98.0
  # or 
  yarn add @datadog/framepost@0.2.5-canary.85.06bae98.0
  yarn add @datadog/ui-extensions-sdk@0.24.6-canary.85.06bae98.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
