### PR TITLE
Fix `changeset` long-running PRs

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+        if: "!contains(github.event.head_commit.message, 'skip canary')"
         steps:
             - uses: actions/checkout@v2
             - name: Prepare repository

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -35,8 +35,8 @@ jobs:
               uses: changesets/action@v1
               with:
                   # `commit` sets the commit message.
-                  # Using `[skip ci]` should force `auto` to ignore these PRs/publishes.
-                  commit: Version Packages [skip ci]
+                  # Using `[skip canary]` should force `auto` to ignore these PRs/publishes.
+                  commit: Version Packages [skip canary]
                   publish: yarn release:packages
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- Whenever a long-running PR branch was opened, we'd be skipping any of the `pull_request`/`push` workflows because we were making commits with `[skip ci]` and GitHub Actions automatically skip commits with that blessed text. We don't want that.

<!-- - Is this a bugfix or a feature? -->

## Changes

- This changes things so we now make a commit with `[skip canary]` and check for that explicitly so we're not dealing with GitHub's blessed behavior.

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

Nothing to check here.

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

- [x] No release is necessary.
    If you're only updating examples/documentation, this is likely what you want.
- [ ] All packages that need a release have a changeset.
