### PR TITLE
Update `node.js` CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,10 @@ jobs:
             - name: checkout
               uses: actions/checkout@v2
             - name: install node
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v2
               with:
-                  node-version: 16.3.0
+                  cache: yarn
+                  node-version-file: .node-version
             - name: install
               run: yarn
             - name: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,25 @@ jobs:
               with:
                   cache: yarn
                   node-version-file: .node-version
+            # The `actions/setup-node` action only caches the global yarn cache.
+            # We explicitly cache the `node_modules`.
+            - name: restore node_modules
+              uses: actions/cache@v2
+              with:
+                  # We want to include the Node.js version in the key.
+                  # Per the documentation,
+                  # caching `node_modules` is unsafe due to changes in Node.js versions.
+                  # If we track the Node.js version,
+                  # it ought to miss the cache whenever the Node.js version changes.
+                  key: node_modules-${{ runner.os }}-${{ hashFiles('.node-version') }}-${{ hashFiles('yarn.lock') }}
+                  path: |
+                      node_modules
+                      **/node_modules
+                  # We only go as far back as the Node.js version.
+                  # We can run into issues if we restore caches from different versions.
+                  # This will check the current branch as well as the parent branch.
+                  restore-keys: |
+                      node_modules-${{ runner.os }}-${{ hashFiles('.node-version') }}-
             - name: install
               run: yarn install --prefer-offline
             - name: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
                   cache: yarn
                   node-version-file: .node-version
             - name: install
-              run: yarn
+              run: yarn install --prefer-offline
             - name: lint
               run: yarn lint
             - name: build

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -18,7 +18,7 @@ jobs:
                   node-version-file: .node-version
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@datadog'
-            - run: yarn
+            - run: yarn install --prefer-offline
             - run: yarn build
             - name: Add auth credentials for lerna
               run: npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -18,6 +18,25 @@ jobs:
                   node-version-file: .node-version
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@datadog'
+            # The `actions/setup-node` action only caches the global yarn cache.
+            # We explicitly cache the `node_modules`.
+            - name: Restore node_modules
+              uses: actions/cache@v2
+              with:
+                  # We want to include the Node.js version in the key.
+                  # Per the documentation,
+                  # caching `node_modules` is unsafe due to changes in Node.js versions.
+                  # If we track the Node.js version,
+                  # it ought to miss the cache whenever the Node.js version changes.
+                  key: node_modules-${{ runner.os }}-${{ hashFiles('.node-version') }}-${{ hashFiles('yarn.lock') }}
+                  path: |
+                      node_modules
+                      **/node_modules
+                  # We only go as far back as the Node.js version.
+                  # We can run into issues if we restore caches from different versions.
+                  # This will check the current branch as well as the parent branch.
+                  restore-keys: |
+                      node_modules-${{ runner.os }}-${{ hashFiles('.node-version') }}-
             - run: yarn install --prefer-offline
             - run: yarn build
             - name: Add auth credentials for lerna

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -12,9 +12,10 @@ jobs:
             - uses: actions/checkout@v2
             - name: Prepare repository
               run: git fetch --unshallow --tags
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v2
               with:
-                  node-version: 16.3.0
+                  cache: yarn
+                  node-version-file: .node-version
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@datadog'
             - run: yarn

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -13,9 +13,10 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Setup Node.js
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v2
               with:
-                  node-version: 16.3.0
+                  cache: yarn
+                  node-version-file: .node-version
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@datadog'
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -21,7 +21,7 @@ jobs:
                   scope: '@datadog'
 
             - name: Install dependencies
-              run: yarn
+              run: yarn install --prefer-offline
 
             - name: Build packages
               run: yarn build

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -20,6 +20,26 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@datadog'
 
+            # The `actions/setup-node` action only caches the global yarn cache.
+            # We explicitly cache the `node_modules`.
+            - name: Resttore node_modules
+              uses: actions/cache@v2
+              with:
+                  # We want to include the Node.js version in the key.
+                  # Per the documentation,
+                  # caching `node_modules` is unsafe due to changes in Node.js versions.
+                  # If we track the Node.js version,
+                  # it ought to miss the cache whenever the Node.js version changes.
+                  key: node_modules-${{ runner.os }}-${{ hashFiles('.node-version') }}-${{ hashFiles('yarn.lock') }}
+                  path: |
+                      node_modules
+                      **/node_modules
+                  # We only go as far back as the Node.js version.
+                  # We can run into issues if we restore caches from different versions.
+                  # This will check the current branch as well as the parent branch.
+                  restore-keys: |
+                      node_modules-${{ runner.os }}-${{ hashFiles('.node-version') }}-
+
             - name: Install dependencies
               run: yarn install --prefer-offline
 


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- We want to make it just a bit easier to maintain CI while also potentially speeding it up.

<!-- - Is this a bugfix or a feature? -->

## Changes

- We bump `actions/setup-node` to v2 and take advantage of the `cache` and `node-version-file` features. For more information, look at the first commit.

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

So long as CI continues to work, this is fine.

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

- [x] No release is necessary.
    If you're only updating examples/documentation, this is likely what you want.
- [ ] All packages that need a release have a changeset.
