### PR TITLE
UIAPPS-70 Setup `typedoc` for API documentation

### DIFF
--- a/.github/workflows/publish-api-documentation.yml
+++ b/.github/workflows/publish-api-documentation.yml
@@ -1,0 +1,35 @@
+name: Publish API documentation
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v2
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 16.3.0
+
+            - name: Install dependencies
+              run: yarn install
+
+            - name: Build all packages
+              run: yarn build
+
+            - name: Build API documentation
+              run: yarn docs
+
+            - name: Deploy to GitHub Pages
+              uses: JamesIves/github-pages-deploy-action@v4.2.2
+              with:
+                # The branch the action should deploy to.
+                branch: gh-pages
+                # The directory the action should deploy.
+                folder: docs/API/packages

--- a/.github/workflows/publish-api-documentation.yml
+++ b/.github/workflows/publish-api-documentation.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Deploy to GitHub Pages
               uses: JamesIves/github-pages-deploy-action@v4.2.2
               with:
-                # The branch the action should deploy to.
-                branch: gh-pages
-                # The directory the action should deploy.
-                folder: docs/API/packages
+                  # The branch the action should deploy to.
+                  branch: gh-pages
+                  # The directory the action should deploy.
+                  folder: docs/API/packages

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -2,6 +2,7 @@ name: Publish canary package
 on:
     push:
         branches-ignore:
+            - "gh-pages"
             - master
 
 jobs:

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -2,7 +2,7 @@ name: Publish canary package
 on:
     push:
         branches-ignore:
-            - "gh-pages"
+            - 'gh-pages'
             - master
 
 jobs:

--- a/docs/API/.gitignore
+++ b/docs/API/.gitignore
@@ -1,0 +1,1 @@
+packages

--- a/docs/API/README.md
+++ b/docs/API/README.md
@@ -1,0 +1,7 @@
+# Datadog Apps API Documentation
+
+This is the API documentation for Datadog Apps packages.
+If you'd like to get started with Datadog Apps,
+see the [official docs][].
+
+[official docs]: https://docs.datadoghq.com/developers/datadog_apps

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     },
     "scripts": {
         "build": "yarn workspaces run build",
+        "docs": "typedoc --options typedoc.js",
         "format": "prettier --write .",
         "lint:check": "eslint '**/*.{ts,js}'",
         "lint:fix": "yarn run lint:check --fix",
@@ -53,6 +54,7 @@
         "eslint": "7.25.0",
         "lerna": "4.0.0",
         "prettier": "2.1.2",
+        "typedoc": "0.22.10",
         "typescript": "4.5.4"
     }
 }

--- a/packages/framepost/package.json
+++ b/packages/framepost/package.json
@@ -40,5 +40,6 @@
         "webpack": "^5.35.1",
         "webpack-cli": "^4.6.0",
         "webpack-dev-server": "3.11.1"
-    }
+    },
+    "typedocMain": "src/index.ts"
 }

--- a/packages/ui-extensions-sdk/package.json
+++ b/packages/ui-extensions-sdk/package.json
@@ -40,5 +40,6 @@
         "webpack": "^5.3.2",
         "webpack-cli": "^4.1.0",
         "webpack-dev-server": "3.11.1"
-    }
+    },
+    "typedocMain": "src/index.ts"
 }

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    entryPoints: ['packages/*'],
+    entryPointStrategy: 'packages',
+    excludePrivate: true,
+    excludeInternal: true,
+    name: 'Datadog Apps API Documentation',
+    out: 'docs/API/packages',
+    readme: 'docs/API/README.md'
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9481,6 +9481,18 @@ glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-dirs@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
@@ -11530,6 +11542,11 @@ json5@^2.1.2, json5@^2.2.0:
   dependencies:
     minimist "^1.2.5"
 
+jsonc-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -12001,6 +12018,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -12104,6 +12126,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+marked@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-3.0.8.tgz#2785f0dc79cbdc6034be4bb4f0f0a396bd3f8aeb"
+  integrity sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -16028,6 +16055,15 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shiki@^0.9.12:
+  version "0.9.15"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.15.tgz#2481b46155364f236651319d2c18e329ead6fa44"
+  integrity sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==
+  dependencies:
+    jsonc-parser "^3.0.0"
+    vscode-oniguruma "^1.6.1"
+    vscode-textmate "5.2.0"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -17418,6 +17454,17 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typedoc@0.22.10:
+  version "0.22.10"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.10.tgz#221e1a2b17bcb71817ef027dc4c4969d572e7620"
+  integrity sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==
+  dependencies:
+    glob "^7.2.0"
+    lunr "^2.3.9"
+    marked "^3.0.8"
+    minimatch "^3.0.4"
+    shiki "^0.9.12"
+
 typeface-roboto@^1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-1.1.13.tgz#9c4517cb91e311706c74823e857b4bac9a764ae5"
@@ -17792,6 +17839,16 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vscode-oniguruma@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz#2bf4dfcfe3dd2e56eb549a3068c8ee39e6c30ce5"
+  integrity sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==
+
+vscode-textmate@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
+  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- Jira Issue: https://datadoghq.atlassian.net/browse/UIAPPS-70
- We have a few packages now that could use with some documentation. Plus we're about to add another one in https://github.com/DataDog/apps/pull/94.

<!-- - Is this a bugfix or a feature? -->

## Changes

- This sets us up with a GitHub Pages build for our documentation. We're using the same package that other repos use for their GitHub Pages builds: https://cs.github.com/?scope=org%3ADataDog&scopeName=DataDog&q=JamesIves%2Fgithub-pages-deploy-action. It should only run when something is pushed to the `master` branch (PR merges count as well).

<!-- - If there's a UI Change: please include a screenshot. -->
<!-- - If there's not a UI Change: please remove this table. -->

The documentation ends up looking like this:

| Docs |
| --- |
| ![Index](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/6quEenbE/eba28e5e-e01f-49ec-9f1f-9a8bd9ebfa51.jpg?v=43c64e65bb501a3fd4d8f8b48360012a) |
| ![Framepost landing page](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/jkumZkR5/10e8d0d5-846e-4be6-8bd7-61b16da69e72.jpg?v=ee6fc5821f5effc746e3b38e471a2a02) |
| ![Framepost details](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/wbuY7g5v/e70bf023-d081-4f57-ae95-1d7dd87c2086.jpg?v=f5fc5e80dc24a595e92848e1ab145700) |
| ![SDK landing page](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/OAu4qyNB/07ad4867-5df1-4c0a-82a5-57c53263b842.jpg?v=9e47467b91043b5c59e3c56e83e00c33) |
| ![SDK details](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/Qwu40ro1/ab786eb8-de20-4446-b92b-df80af534843.jpg?v=d7613d35d1bb772476908f7705dd9d7c) |

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

I think the only way to see this yourself, at the moment, is to checkout this branch and run `yarn docs`. You might have to `yarn install` first, not sure.

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [x] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/create-app@1.0.3-canary.95.6bbaffa.0
  npm install @datadog/framepost@0.3.1-canary.95.6bbaffa.0
  npm install @datadog/ui-extensions-sdk@0.25.1-canary.95.6bbaffa.0
  # or 
  yarn add @datadog/create-app@1.0.3-canary.95.6bbaffa.0
  yarn add @datadog/framepost@0.3.1-canary.95.6bbaffa.0
  yarn add @datadog/ui-extensions-sdk@0.25.1-canary.95.6bbaffa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
