### PR TITLE
UIAPPS-70 Set the committer to the bot

### DIFF
--- a/.github/workflows/publish-api-documentation.yml
+++ b/.github/workflows/publish-api-documentation.yml
@@ -33,3 +33,5 @@ jobs:
                   branch: gh-pages
                   # The directory the action should deploy.
                   folder: docs/API/packages
+                  git-config-name: github-actions[bot]
+                  git-config-email: github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- Jira Issue: https://datadoghq.atlassian.net/browse/UIAPPS-70
- These docs commits were being made as the wrong person. Since we're not actually making the commits, it seems weird to attribute them to individuals rather than the actual bot doing the work.

<!-- - Is this a bugfix or a feature? -->

## Changes

- This should make it so the actual bot is the committer.

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

Nothing really to test.

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [x] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/create-app@1.0.3-canary.96.dca8397.0
  npm install @datadog/framepost@0.3.1-canary.96.dca8397.0
  npm install @datadog/ui-extensions-sdk@0.25.1-canary.96.dca8397.0
  # or 
  yarn add @datadog/create-app@1.0.3-canary.96.dca8397.0
  yarn add @datadog/framepost@0.3.1-canary.96.dca8397.0
  yarn add @datadog/ui-extensions-sdk@0.25.1-canary.96.dca8397.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
