### PR TITLE
UIAPPS-151 Fix creating an App

### DIFF
--- a/examples/geomap/setup/createDatadogApp.js
+++ b/examples/geomap/setup/createDatadogApp.js
@@ -19,7 +19,14 @@ async function getAppsData() {
         );
 }
 
-async function createApp(endpoint, method) {
+/**
+ * Upserts an App.
+ * @param {string} endpoint The API to make the request to
+ * @param {'POST' | 'PATCH'} method The HTTP method to use.
+ * @param {string} [appId] The App id, if it exists. If the {@link method} is 'PATCH', this must be provided.
+ * @returns {Promise<string>} The upserted App id.
+ */
+async function createApp(endpoint, method, appId) {
     return fetch(endpoint, {
         headers: {
             'content-type': 'application/json',
@@ -29,6 +36,7 @@ async function createApp(endpoint, method) {
         body: JSON.stringify({
             data: {
                 type: 'apps',
+                id: appId,
                 attributes: {
                     author_info: {
                         name: 'Thomas Dimnet'
@@ -98,7 +106,7 @@ async function main() {
 
     const method = existingApp ? 'PATCH' : 'POST';
 
-    const appId = await createApp(endpoint, method);
+    const appId = await createApp(endpoint, method, existingApp?.id);
     return appId;
 }
 

--- a/examples/geomap/setup/createDatadogApp.js
+++ b/examples/geomap/setup/createDatadogApp.js
@@ -21,12 +21,16 @@ async function getAppsData() {
 
 /**
  * Upserts an App.
- * @param {string} endpoint The API to make the request to
- * @param {'POST' | 'PATCH'} method The HTTP method to use.
- * @param {string} [appId] The App id, if it exists. If the {@link method} is 'PATCH', this must be provided.
+ * @param {string} [appId] The App id, if it exists.
  * @returns {Promise<string>} The upserted App id.
  */
-async function createApp(endpoint, method, appId) {
+async function createApp(appId) {
+    const endpoint = appId
+        ? `${BASE_URL}/api/v2/apps/${appId}`
+        : `${BASE_URL}/api/v2/apps`;
+
+    const method = appId ? 'PATCH' : 'POST';
+
     return fetch(endpoint, {
         headers: {
             'content-type': 'application/json',
@@ -100,13 +104,7 @@ async function main() {
         app => app.attributes.tile.title === APP_NAME
     );
 
-    const endpoint = existingApp
-        ? `${BASE_URL}/api/v2/apps/${existingApp.id}`
-        : `${BASE_URL}/api/v2/apps`;
-
-    const method = existingApp ? 'PATCH' : 'POST';
-
-    const appId = await createApp(endpoint, method, existingApp?.id);
+    const appId = await createApp(existingApp?.id);
     return appId;
 }
 

--- a/examples/random-dog/setup/createDatadogApp.js
+++ b/examples/random-dog/setup/createDatadogApp.js
@@ -58,7 +58,7 @@ async function createApp(endpoint, method) {
                                 },
                                 {
                                     name: 'widget_context_menu',
-                                    options: {}
+                                    options: { items: [] }
                                 },
                                 {
                                     name: 'modals',

--- a/examples/random-dog/setup/createDatadogApp.js
+++ b/examples/random-dog/setup/createDatadogApp.js
@@ -21,12 +21,16 @@ async function getAppsData() {
 
 /**
  * Upserts an App.
- * @param {string} endpoint The API to make the request to
- * @param {'POST' | 'PATCH'} method The HTTP method to use.
- * @param {string} [appId] The App id, if it exists. If the {@link method} is 'PATCH', this must be provided.
+ * @param {string} [appId] The App id, if it exists.
  * @returns {Promise<string>} The upserted App id.
  */
-async function createApp(endpoint, method, appId) {
+async function createApp(appId) {
+    const endpoint = appId
+        ? `${BASE_URL}/api/v2/apps/${appId}`
+        : `${BASE_URL}/api/v2/apps`;
+
+    const method = appId ? 'PATCH' : 'POST';
+
     return fetch(endpoint, {
         headers: {
             'content-type': 'application/json',
@@ -113,13 +117,7 @@ async function main(configuration) {
         app => app.attributes.tile.title === APP_NAME
     );
 
-    const endpoint = existingApp
-        ? `${BASE_URL}/api/v2/apps/${existingApp.id}`
-        : `${BASE_URL}/api/v2/apps`;
-
-    const method = existingApp ? 'PATCH' : 'POST';
-
-    const appId = await createApp(endpoint, method, existingApp?.id);
+    const appId = await createApp(existingApp?.id);
     return appId;
 }
 

--- a/examples/random-dog/setup/createDatadogApp.js
+++ b/examples/random-dog/setup/createDatadogApp.js
@@ -19,7 +19,14 @@ async function getAppsData() {
         });
 }
 
-async function createApp(endpoint, method) {
+/**
+ * Upserts an App.
+ * @param {string} endpoint The API to make the request to
+ * @param {'POST' | 'PATCH'} method The HTTP method to use.
+ * @param {string} [appId] The App id, if it exists. If the {@link method} is 'PATCH', this must be provided.
+ * @returns {Promise<string>} The upserted App id.
+ */
+async function createApp(endpoint, method, appId) {
     return fetch(endpoint, {
         headers: {
             'content-type': 'application/json',
@@ -29,6 +36,7 @@ async function createApp(endpoint, method) {
         body: JSON.stringify({
             data: {
                 type: 'apps',
+                id: appId,
                 attributes: {
                     author_info: {
                         name: 'Duncan Harvey'
@@ -111,7 +119,7 @@ async function main(configuration) {
 
     const method = existingApp ? 'PATCH' : 'POST';
 
-    const appId = await createApp(endpoint, method);
+    const appId = await createApp(endpoint, method, existingApp?.id);
     return appId;
 }
 

--- a/examples/redis/setup/createDatadogApp.js
+++ b/examples/redis/setup/createDatadogApp.js
@@ -19,7 +19,14 @@ async function getAppsData() {
         );
 }
 
-async function createApp(endpoint, method) {
+/**
+ * Upserts an App.
+ * @param {string} endpoint The API to make the request to
+ * @param {'POST' | 'PATCH'} method The HTTP method to use.
+ * @param {string} [appId] The App id, if it exists. If the {@link method} is 'PATCH', this must be provided.
+ * @returns {Promise<string>} The upserted App id.
+ */
+async function createApp(endpoint, method, appId) {
     return fetch(endpoint, {
         headers: {
             'content-type': 'application/json',
@@ -29,6 +36,7 @@ async function createApp(endpoint, method) {
         body: JSON.stringify({
             data: {
                 type: 'apps',
+                id: appId,
                 attributes: {
                     author_info: {
                         name: 'Thomas Dimnet'
@@ -113,7 +121,7 @@ async function main() {
 
     const method = existingApp ? 'PATCH' : 'POST';
 
-    const appId = await createApp(endpoint, method);
+    const appId = await createApp(endpoint, method, existingApp?.id);
     return appId;
 }
 

--- a/examples/redis/setup/createDatadogApp.js
+++ b/examples/redis/setup/createDatadogApp.js
@@ -21,12 +21,16 @@ async function getAppsData() {
 
 /**
  * Upserts an App.
- * @param {string} endpoint The API to make the request to
- * @param {'POST' | 'PATCH'} method The HTTP method to use.
- * @param {string} [appId] The App id, if it exists. If the {@link method} is 'PATCH', this must be provided.
+ * @param {string} [appId] The App id, if it exists.
  * @returns {Promise<string>} The upserted App id.
  */
-async function createApp(endpoint, method, appId) {
+async function createApp(appId) {
+    const endpoint = appId
+        ? `${BASE_URL}/api/v2/apps/${appId}`
+        : `${BASE_URL}/api/v2/apps`;
+
+    const method = appId ? 'PATCH' : 'POST';
+
     return fetch(endpoint, {
         headers: {
             'content-type': 'application/json',
@@ -115,13 +119,7 @@ async function main() {
         app => app.attributes.tile.title === APP_NAME
     );
 
-    const endpoint = existingApp
-        ? `${BASE_URL}/api/v2/apps/${existingApp.id}`
-        : `${BASE_URL}/api/v2/apps`;
-
-    const method = existingApp ? 'PATCH' : 'POST';
-
-    const appId = await createApp(endpoint, method, existingApp?.id);
+    const appId = await createApp(existingApp?.id);
     return appId;
 }
 

--- a/examples/stream/setup/create-app.js
+++ b/examples/stream/setup/create-app.js
@@ -73,7 +73,7 @@ const createAppEntry = async configuration => {
                                 },
                                 {
                                     name: 'widget_context_menu',
-                                    options: {}
+                                    options: { items: [] }
                                 },
                                 {
                                     name: 'modals',

--- a/examples/stream/setup/create-app.js
+++ b/examples/stream/setup/create-app.js
@@ -43,6 +43,7 @@ const createAppEntry = async configuration => {
         body: JSON.stringify({
             data: {
                 type: 'apps',
+                id: existingApp?.id,
                 attributes: {
                     author_info: {
                         name: 'Ivan Di Lernia'


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

-  Jira Issue: https://datadoghq.atlassian.net/browse/UIAPPS-151
- Currently, creating an App doesn't work with the `setup` packages. We changed our API, and missed updating these packages.

<!-- - Is this a bugfix or a feature? -->

## Changes

- We update the `setup` packages so they work with the new API changes.

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

- You can try running through at least the `stream` setup. First, make (or find) an API key and an Application key. then run this line:
    ```Console
    DD_SITE=datadoghq.com \
    DD_API_KEY=<API key> \
    DD_APP_KEY=<Application key> \
    APP_UI_URL=http://localhost:3000 \
    SERVER_URL=http://localhost:3001 \
    ADMIN_UI_URL=http://localhost:3002 \
    yarn workspace datadog-app-example-stream-setup start
    ```
- It should create the App, and a dashboard. You can delete them afterward.

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [x] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.
