### PR TITLE
UIAPPS-90 Always validate features when receiving/sending requests

### DIFF
--- a/.changeset/tasty-forks-burn.md
+++ b/.changeset/tasty-forks-burn.md
@@ -1,0 +1,10 @@
+---
+'@datadog/ui-extensions-sdk': patch
+---
+
+Fix custom widgets not validating the feature is enabled.
+
+For consistency with the other features,
+we make sure that `DDDashboardCustomWidgetClient.updateOptions` validates that the `FeatureType.DASHBOARD_CUSTOM_WIDGET` feature is enabled.
+It's likely that the parent wouldn't allow this,
+but the error message is more consistent on the SDK-side of things.

--- a/.changeset/tasty-forks-burn.md
+++ b/.changeset/tasty-forks-burn.md
@@ -1,4 +1,5 @@
 ---
+'@datadog/ui-extensions-react': patch
 '@datadog/ui-extensions-sdk': patch
 ---
 

--- a/packages/ui-extensions-sdk/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.test.ts
+++ b/packages/ui-extensions-sdk/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.test.ts
@@ -12,6 +12,23 @@ beforeEach(() => {
 });
 
 describe('dashboardContextMenu.onRequestItems()', () => {
+    test('throws an error if `DASHBOARD_COG_MENU` is not enabled', async () => {
+        client.framePostClient.init({
+            ...mockContext,
+            app: {
+                ...mockContext.app,
+                features: []
+            }
+        });
+
+        const response = client.framePostClient.mockRequest(
+            RequestType.GET_DASHBOARD_COG_MENU_ITEMS,
+            'data'
+        );
+
+        await expect(response).rejects.toBeInstanceOf(Error);
+    });
+
     test('Registers a handler returning an empty array on init', async () => {
         client.framePostClient.init({
             ...mockContext,

--- a/packages/ui-extensions-sdk/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
+++ b/packages/ui-extensions-sdk/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
@@ -32,7 +32,6 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
         const wrappedHandler = async (
             context: GetDashboardCogMenuItemsRequest
         ): Promise<GetDashboardCogMenuItemsResponse> => {
-
             const { items } = await requestHandler(context);
 
             return {

--- a/packages/ui-extensions-sdk/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
+++ b/packages/ui-extensions-sdk/src/dashboard/dashboard-cog-menu/dashboard-cog-menu.ts
@@ -32,7 +32,6 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
         const wrappedHandler = async (
             context: GetDashboardCogMenuItemsRequest
         ): Promise<GetDashboardCogMenuItemsResponse> => {
-            await this.validateFeatureIsEnabled();
 
             const { items } = await requestHandler(context);
 
@@ -42,7 +41,7 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
                         validateKey(item);
                     } catch (e) {
                         if (e instanceof Error) {
-                            this.client.logError(e.message);
+                            this.logError(e.message);
                         }
 
                         return false;
@@ -53,7 +52,7 @@ export class DDDashboardCogMenuClient extends DDFeatureClient {
             };
         };
 
-        this.client.onRequest(
+        this.handleRequest(
             RequestType.GET_DASHBOARD_COG_MENU_ITEMS,
             wrappedHandler
         );

--- a/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.test.ts
+++ b/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.test.ts
@@ -27,7 +27,7 @@ describe('DDDashboardCustomWidgetClient', () => {
             expect(requestSpy).not.toHaveBeenCalled();
         });
 
-        test('does not throw an error if `DASHBOARD_CUSTOM_WIDGET` is not enabled', async () => {
+        test('throws an error if `DASHBOARD_CUSTOM_WIDGET` is not enabled', async () => {
             const client = new MockClient();
             const context: Context = {
                 ...mockContext,
@@ -56,21 +56,8 @@ describe('DDDashboardCustomWidgetClient', () => {
                 }
             ]);
 
-            await expect(response).resolves.not.toBeInstanceOf(Error);
-            expect(requestSpy).toHaveBeenCalledWith(
-                'dashboard_custom_widget_options_update',
-                {
-                    customWidgetID: 1,
-                    customWidgetKey: 'key',
-                    newOptions: [
-                        {
-                            type: WidgetOptionItemType.BOOLEAN,
-                            label: 'option',
-                            name: 'option'
-                        }
-                    ]
-                }
-            );
+            await expect(response).rejects.toBeInstanceOf(Error);
+            expect(requestSpy).not.toHaveBeenCalledWith();
         });
 
         test('sends a request if `DASHBOARD_CUSTOM_WIDGET` is enabled', async () => {

--- a/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.test.ts
+++ b/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.test.ts
@@ -1,0 +1,122 @@
+import { FeatureType, WidgetOptionItemType } from '../../constants';
+import { Context } from '../../types';
+import { MockClient, mockContext } from '../../utils/testUtils';
+
+import { DDDashboardCustomWidgetClient } from './dashboard-custom-widget';
+
+describe('DDDashboardCustomWidgetClient', () => {
+    describe('updateOptions', () => {
+        test('does not sends a request if there is no widget', async () => {
+            const client = new MockClient();
+            const context: Context = {
+                ...mockContext,
+                app: {
+                    ...mockContext.app,
+                    features: [FeatureType.DASHBOARD_CUSTOM_WIDGET]
+                }
+            };
+            client.framePostClient.init(context);
+            const dashboardCustomWidgetClient = new DDDashboardCustomWidgetClient(
+                client
+            );
+            const requestSpy = jest.spyOn(client, 'request');
+
+            const response = dashboardCustomWidgetClient.updateOptions([]);
+
+            await expect(response).resolves.toEqual(undefined);
+            expect(requestSpy).not.toHaveBeenCalled();
+        });
+
+        test('does not throw an error if `DASHBOARD_CUSTOM_WIDGET` is not enabled', async () => {
+            const client = new MockClient();
+            const context: Context = {
+                ...mockContext,
+                app: {
+                    ...mockContext.app,
+                    features: []
+                },
+                widget: {
+                    definition: {
+                        custom_widget_key: 'key'
+                    },
+                    id: 1
+                }
+            };
+            client.framePostClient.init(context);
+            const dashboardCustomWidgetClient = new DDDashboardCustomWidgetClient(
+                client
+            );
+            const requestSpy = jest.spyOn(client, 'request');
+
+            const response = dashboardCustomWidgetClient.updateOptions([
+                {
+                    type: WidgetOptionItemType.BOOLEAN,
+                    label: 'option',
+                    name: 'option'
+                }
+            ]);
+
+            await expect(response).resolves.not.toBeInstanceOf(Error);
+            expect(requestSpy).toHaveBeenCalledWith(
+                'dashboard_custom_widget_options_update',
+                {
+                    customWidgetID: 1,
+                    customWidgetKey: 'key',
+                    newOptions: [
+                        {
+                            type: WidgetOptionItemType.BOOLEAN,
+                            label: 'option',
+                            name: 'option'
+                        }
+                    ]
+                }
+            );
+        });
+
+        test('sends a request if `DASHBOARD_CUSTOM_WIDGET` is enabled', async () => {
+            const client = new MockClient();
+            const context: Context = {
+                ...mockContext,
+                app: {
+                    ...mockContext.app,
+                    features: [FeatureType.DASHBOARD_CUSTOM_WIDGET]
+                },
+                widget: {
+                    definition: {
+                        custom_widget_key: 'key'
+                    },
+                    id: 1
+                }
+            };
+            client.framePostClient.init(context);
+            const dashboardCustomWidgetClient = new DDDashboardCustomWidgetClient(
+                client
+            );
+            const requestSpy = jest.spyOn(client, 'request');
+
+            const response = dashboardCustomWidgetClient.updateOptions([
+                {
+                    type: WidgetOptionItemType.BOOLEAN,
+                    label: 'option',
+                    name: 'option'
+                }
+            ]);
+
+            await expect(response).resolves.toEqual(undefined);
+            expect(requestSpy).toHaveBeenCalledWith(
+                'dashboard_custom_widget_options_update',
+                {
+                    customWidgetID: 1,
+                    customWidgetKey: 'key',
+                    newOptions: [
+                        {
+                            type: WidgetOptionItemType.BOOLEAN,
+                            label: 'option',
+                            name: 'option'
+                        }
+                    ]
+                }
+            );
+        });
+    });
+});

--- a/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -13,10 +13,9 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
     }
 
     async updateOptions(newOptions: WidgetOptionItem[]) {
-        const { widget } = await this.client.getContext();
+        const { widget } = await this.getContext();
         if (widget?.definition && widget?.id) {
-            await this.validateFeatureIsEnabled();
-            return this.client.request(
+            return this.sendRequest(
                 RequestType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE,
                 {
                     customWidgetKey: widget.definition.custom_widget_key,

--- a/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -15,6 +15,7 @@ export class DDDashboardCustomWidgetClient extends DDFeatureClient {
     async updateOptions(newOptions: WidgetOptionItem[]) {
         const { widget } = await this.client.getContext();
         if (widget?.definition && widget?.id) {
+            await this.validateFeatureIsEnabled();
             return this.client.request(
                 RequestType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE,
                 {

--- a/packages/ui-extensions-sdk/src/modal/modal.ts
+++ b/packages/ui-extensions-sdk/src/modal/modal.ts
@@ -18,7 +18,6 @@ export class DDModalClient extends DDFeatureClient {
      * definition pre-defined in the app manifest
      */
     async open(definition: ModalDefinition, args?: unknown) {
-
         if (validateKey(definition)) {
             return this.sendRequest(RequestType.OPEN_MODAL, {
                 definition,
@@ -32,7 +31,6 @@ export class DDModalClient extends DDFeatureClient {
      * if it matches the provided key.
      */
     async close(key?: string) {
-
         return this.sendRequest(RequestType.CLOSE_MODAL, key);
     }
 }

--- a/packages/ui-extensions-sdk/src/modal/modal.ts
+++ b/packages/ui-extensions-sdk/src/modal/modal.ts
@@ -18,10 +18,9 @@ export class DDModalClient extends DDFeatureClient {
      * definition pre-defined in the app manifest
      */
     async open(definition: ModalDefinition, args?: unknown) {
-        await this.validateFeatureIsEnabled();
 
         if (validateKey(definition)) {
-            return this.client.request(RequestType.OPEN_MODAL, {
+            return this.sendRequest(RequestType.OPEN_MODAL, {
                 definition,
                 args
             });
@@ -33,8 +32,7 @@ export class DDModalClient extends DDFeatureClient {
      * if it matches the provided key.
      */
     async close(key?: string) {
-        await this.validateFeatureIsEnabled();
 
-        return this.client.request(RequestType.CLOSE_MODAL, key);
+        return this.sendRequest(RequestType.CLOSE_MODAL, key);
     }
 }

--- a/packages/ui-extensions-sdk/src/shared/feature-client.ts
+++ b/packages/ui-extensions-sdk/src/shared/feature-client.ts
@@ -1,9 +1,15 @@
-import type { FeatureType } from '../constants';
-import { ContextClient, LoggerClient, RequestClient } from '../types';
+import type { FeatureType, RequestType } from '../constants';
+import {
+    Context,
+    ContextClient,
+    LoggerClient,
+    RequestClient,
+    RequestHandler
+} from '../types';
 import { isFeatureEnabled } from '../utils/utils';
 
 export class DDFeatureClient {
-    protected readonly client: ContextClient & LoggerClient & RequestClient;
+    private readonly client: ContextClient & LoggerClient & RequestClient;
     protected readonly featureType: FeatureType;
 
     constructor(
@@ -12,6 +18,34 @@ export class DDFeatureClient {
     ) {
         this.client = client;
         this.featureType = featureType;
+    }
+
+    protected getContext(): Promise<Context> {
+        return this.client.getContext();
+    }
+
+    protected handleRequest<Q = unknown, R = unknown>(
+        requestType: RequestType,
+        requestHandler: RequestHandler<Q, R | Promise<R>>
+    ): () => void {
+        const wrappedHandler = async (requestData: Q): Promise<R> => {
+            await this.validateFeatureIsEnabled();
+            return requestHandler(requestData);
+        };
+
+        return this.client.onRequest(requestType, wrappedHandler);
+    }
+
+    protected logError(message: string): void {
+        return this.client.logError(message);
+    }
+
+    protected async sendRequest<Q = unknown, R = unknown>(
+        requestType: RequestType,
+        requestData?: Q
+    ): Promise<R> {
+        await this.validateFeatureIsEnabled();
+        return this.client.request(requestType, requestData);
     }
 
     private async isEnabled(): Promise<boolean> {
@@ -24,7 +58,7 @@ export class DDFeatureClient {
         return isFeatureEnabled(this.featureType, features);
     }
 
-    protected async validateFeatureIsEnabled() {
+    private async validateFeatureIsEnabled() {
         const isEnabled = await this.isEnabled();
 
         if (!isEnabled) {

--- a/packages/ui-extensions-sdk/src/side-panel/side-panel.ts
+++ b/packages/ui-extensions-sdk/src/side-panel/side-panel.ts
@@ -18,7 +18,6 @@ export class DDSidePanelClient extends DDFeatureClient {
      * definition pre-defined in the app manifest
      */
     async open(definition: SidePanelDefinition, args?: unknown) {
-
         if (validateKey(definition)) {
             return this.sendRequest(RequestType.OPEN_SIDE_PANEL, {
                 definition,
@@ -32,7 +31,6 @@ export class DDSidePanelClient extends DDFeatureClient {
      * if it matches the provided key.
      */
     async close(key?: string) {
-
         return this.sendRequest(RequestType.CLOSE_SIDE_PANEL, key);
     }
 }

--- a/packages/ui-extensions-sdk/src/side-panel/side-panel.ts
+++ b/packages/ui-extensions-sdk/src/side-panel/side-panel.ts
@@ -18,10 +18,9 @@ export class DDSidePanelClient extends DDFeatureClient {
      * definition pre-defined in the app manifest
      */
     async open(definition: SidePanelDefinition, args?: unknown) {
-        await this.validateFeatureIsEnabled();
 
         if (validateKey(definition)) {
-            return this.client.request(RequestType.OPEN_SIDE_PANEL, {
+            return this.sendRequest(RequestType.OPEN_SIDE_PANEL, {
                 definition,
                 args
             });
@@ -33,8 +32,7 @@ export class DDSidePanelClient extends DDFeatureClient {
      * if it matches the provided key.
      */
     async close(key?: string) {
-        await this.validateFeatureIsEnabled();
 
-        return this.client.request(RequestType.CLOSE_SIDE_PANEL, key);
+        return this.sendRequest(RequestType.CLOSE_SIDE_PANEL, key);
     }
 }

--- a/packages/ui-extensions-sdk/src/widget-context-menu/widget-context-menu.test.ts
+++ b/packages/ui-extensions-sdk/src/widget-context-menu/widget-context-menu.test.ts
@@ -12,6 +12,23 @@ beforeEach(() => {
 });
 
 describe('dashboardContextMenu.onRequestItems()', () => {
+    test('throws an error if `WIDGET_CONTEXT_MENU` is not enabled', async () => {
+        client.framePostClient.init({
+            ...mockContext,
+            app: {
+                ...mockContext.app,
+                features: []
+            }
+        });
+
+        const response = client.framePostClient.mockRequest(
+            RequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
+            'data'
+        );
+
+        await expect(response).rejects.toBeInstanceOf(Error);
+    });
+
     test('Registers a handler returning an empty array on init', async () => {
         client.framePostClient.init({
             ...mockContext,

--- a/packages/ui-extensions-sdk/src/widget-context-menu/widget-context-menu.ts
+++ b/packages/ui-extensions-sdk/src/widget-context-menu/widget-context-menu.ts
@@ -32,7 +32,6 @@ export class DDWidgetContextMenuClient extends DDFeatureClient {
         const wrappedHandler = async (
             context: GetWidgetContextMenuItemsRequest
         ): Promise<GetWidgetContextMenuItemsResponse> => {
-
             const { items } = await requestHandler(context);
 
             return {

--- a/packages/ui-extensions-sdk/src/widget-context-menu/widget-context-menu.ts
+++ b/packages/ui-extensions-sdk/src/widget-context-menu/widget-context-menu.ts
@@ -32,7 +32,6 @@ export class DDWidgetContextMenuClient extends DDFeatureClient {
         const wrappedHandler = async (
             context: GetWidgetContextMenuItemsRequest
         ): Promise<GetWidgetContextMenuItemsResponse> => {
-            await this.validateFeatureIsEnabled();
 
             const { items } = await requestHandler(context);
 
@@ -42,7 +41,7 @@ export class DDWidgetContextMenuClient extends DDFeatureClient {
                         validateKey(item);
                     } catch (e) {
                         if (e instanceof Error) {
-                            this.client.logError(e.message);
+                            this.logError(e.message);
                         }
 
                         return false;
@@ -53,7 +52,7 @@ export class DDWidgetContextMenuClient extends DDFeatureClient {
             };
         };
 
-        this.client.onRequest(
+        this.handleRequest(
             RequestType.GET_WIDGET_CONTEXT_MENU_ITEMS,
             wrappedHandler
         );


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- Jira Issue: https://datadoghq.atlassian.net/browse/UIAPPS-90
- This is some pre-work. While working through moving the feature, I noticed that we were being inconsistent in our validation. So before getting too deep in the actual feature, we address the inconsistency.

<!-- - Is this a bugfix or a feature? -->

## Changes

- This PR makes it so anytime we receive or send a request, we validate that the feature is enabled.
- Might be easier to go commit-by-commit on this one.

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [x] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/ui-extensions-sdk@0.27.1-canary.103.efd6bc3.0
  # or 
  yarn add @datadog/ui-extensions-sdk@0.27.1-canary.103.efd6bc3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
