### PR TITLE
UIAPPS-90 Handle custom widget options requests

### DIFF
--- a/.changeset/honest-chairs-pump.md
+++ b/.changeset/honest-chairs-pump.md
@@ -1,0 +1,83 @@
+---
+'@datadog/ui-extensions-react': minor
+'@datadog/ui-extensions-sdk': minor
+---
+
+Handle custom widget dynamic options from the controller instead of sending them from the widget.
+
+Before, the dynamic options could only be sent from the widget using `DDDashboardCustomWidgetClient.updateOptions`.
+For example:
+
+```TypeScript
+import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+import * as React from 'react';
+
+const client = uiExtensionsSDK.init();
+
+export const CustomWidget: React.FunctionComponent = () => {
+    …
+
+    client.dashboard.customWidget.updateOptions([
+      {
+        type: uiExtensionsSDK.WidgetOptionItemType.BOOLEAN,
+        name: 'option-1',
+        label: 'Enable option 1?',
+      },
+      {
+        type: uiExtensionsSDK.WidgetOptionItemType.BOOLEAN,
+        name: 'option-2',
+        label: 'Enable option 2?',
+      },
+    ]);
+
+    …
+}
+```
+
+This patterned allowed App developers to control when and how to update the dynamic options of a custom widget.
+Over time,
+we've found that this pattern has a few flaws and doesn't line up with the other dynamic behavior in the SDK.
+
+We're moving to a more consistent pattern for custom widget dynamic options.
+Instead of the App developer controlling lifecycle of dynamic options from the widget,
+The App developer will need to respond to requests for the dynamic options from the controller using `DDDashboardCustomWidgetClient.onOptionsRequest`.
+This is similar to how dashboard cog menu items and widget context menu items work.
+
+The above example would move from the widget file to the controller:
+
+```TypeScript
+import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+
+export function setup() {
+    const client = uiExtensionsSDK.init();
+    …
+
+    client.dashboard.customWidget.onOptionsRequest(
+        async (
+            request: uiExtensionsSDK.GetDashboardCustomWidgetOptionsRequest
+        ): Promise<uiExtensionsSDK.GetDashboardCustomWidgetOptionsResponse> => {
+            return {
+                options: [
+                    {
+                        type: uiExtensionsSDK.WidgetOptionItemType.BOOLEAN,
+                        name: 'option-1',
+                        label: 'Enable option 1?',
+                    },
+                    {
+                        type: uiExtensionsSDK.WidgetOptionItemType.BOOLEAN,
+                        name: 'option-2',
+                        label: 'Enable option 2?',
+                    },
+                ],
+            };
+        }
+    );
+
+    …
+}
+```
+
+This should still allow most all of the same behavior as before,
+but it will have to happen in the controller instead of in the widget.
+
+The previous behavior using `DDDashboardCustomWidgetClient.updateOptions` is deprecated and will be removed in a future release.

--- a/docs/en/programming-model.md
+++ b/docs/en/programming-model.md
@@ -263,19 +263,23 @@ Widget options can be updated at runtime. This is useful if you need to fill the
 
 ![options](https://user-images.githubusercontent.com/1262407/116876143-f91ba400-abe9-11eb-83d2-c804c3f9f218.gif)
 
-Important: This code needs to run in the widget code and not in the main controller.
+Important: This code needs to run in the main controller and not in the widget code.
 
 ```js
-client.dashboard.customWidget.updateOptions([
-  {
-    type: WidgetOptionItemType.STRING,
-    name: 'favorite-cheese',
-    label: 'Your favorite cheese',
-    enum: ['Chevre', 'Gruyere', 'Mozzarella', 'default'],
-    // enforce a specific order to display the field in the widget editor
-    order: 1,
-  },
-]);
+client.dashboard.customWidget.onOptionsRequest(() => {
+  return {
+    options: [
+      {
+        type: WidgetOptionItemType.STRING,
+        name: 'favorite-cheese',
+        label: 'Your favorite cheese',
+        enum: ['Chevre', 'Gruyere', 'Mozzarella', 'default'],
+        // enforce a specific order to display the field in the widget editor
+        order: 1,
+      },
+    ],
+  };
+});
 ```
 
 

--- a/examples/random-dog/dog-image-widget/src/controller/custom-widget.ts
+++ b/examples/random-dog/dog-image-widget/src/controller/custom-widget.ts
@@ -1,0 +1,62 @@
+import {
+    DDClient,
+    GetDashboardCustomWidgetOptionsRequest,
+    GetDashboardCustomWidgetOptionsResponse,
+    WidgetOptionItemType
+} from '@datadog/ui-extensions-sdk';
+
+type Breed = {
+    id: number;
+    name: string;
+};
+
+type WidgetOptionEnum = {
+    label: string;
+    value: string;
+};
+
+export const setupCustomWidget = (client: DDClient): void => {
+    const breedsResponse: Promise<Breed[] | void> = fetch(
+        'http://localhost:3001/breeds'
+    )
+        .then(res => res.json())
+        .then(res => res.breeds)
+        .catch(err => console.log('An error occurred fetching breeds', err));
+
+    client.dashboard.customWidget.onOptionsRequest(
+        async (
+            request: GetDashboardCustomWidgetOptionsRequest
+        ): Promise<GetDashboardCustomWidgetOptionsResponse> => {
+            const breeds = await breedsResponse;
+            if (breeds == null || breeds.length === 0) {
+                return { options: [] };
+            }
+
+            const enumOptions: WidgetOptionEnum[] = [
+                {
+                    label: 'All Breeds',
+                    value: '0'
+                }
+            ].concat(
+                breeds.map(
+                    (breed: Breed): WidgetOptionEnum => ({
+                        label: breed.name,
+                        value: breed.id.toString()
+                    })
+                )
+            );
+
+            return {
+                options: [
+                    {
+                        type: WidgetOptionItemType.STRING,
+                        name: 'breed',
+                        label: 'Select a Dog Breed to get Random Images of',
+                        enum: enumOptions,
+                        order: 1
+                    }
+                ]
+            };
+        }
+    );
+};

--- a/examples/random-dog/dog-image-widget/src/controller/index.ts
+++ b/examples/random-dog/dog-image-widget/src/controller/index.ts
@@ -1,7 +1,9 @@
 import { init } from '@datadog/ui-extensions-sdk';
+import { setupCustomWidget } from './custom-widget';
 
 export default function setup() {
-    init();
+    const client = init();
+    setupCustomWidget(client);
 
     const root = document.getElementById('root');
     if (!root) {

--- a/examples/random-dog/dog-image-widget/src/widget/index.tsx
+++ b/examples/random-dog/dog-image-widget/src/widget/index.tsx
@@ -1,9 +1,5 @@
 import { useContext } from '@datadog/ui-extensions-react';
-import {
-    WidgetOptionItemType,
-    init,
-    EventType
-} from '@datadog/ui-extensions-sdk';
+import { EventType, init } from '@datadog/ui-extensions-sdk';
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -15,44 +11,8 @@ import 'milligram';
 const client = init();
 
 function Widget() {
-    const [breeds, setBreeds] = useState([]);
     const [image, setImage] = useState(null);
     const context = useContext(client);
-
-    useEffect(() => {
-        fetch('http://localhost:3001/breeds')
-            .then(res => res.json())
-            .then(({ breeds }) => setBreeds(breeds))
-            .catch(err =>
-                console.log('An error occurs on fetching breeds', err)
-            );
-    }, []);
-
-    useEffect(() => {
-        if (breeds.length) {
-            const options = [
-                {
-                    label: 'All Breeds',
-                    value: '0'
-                }
-            ].concat(
-                breeds.map(breed => ({
-                    label: breed['name'] as string,
-                    value: breed['id'] as string
-                }))
-            );
-
-            client.dashboard.customWidget.updateOptions([
-                {
-                    type: WidgetOptionItemType.STRING,
-                    name: 'breed',
-                    label: 'Select a Dog Breed to get Random Images of',
-                    enum: options,
-                    order: 1
-                }
-            ]);
-        }
-    }, [breeds]);
 
     useEffect(() => {
         client.events.on(

--- a/packages/ui-extensions-sdk/src/constants.ts
+++ b/packages/ui-extensions-sdk/src/constants.ts
@@ -81,7 +81,11 @@ export enum RequestType {
     SET_DASHBOARD_CURSOR = 'set_dashboard_cursor',
 
     // Widgets
-    DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE = 'dashboard_custom_widget_options_update'
+    /**
+     * @deprecated Subscribe to and handle requests from {@link GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS} instead of sending requests with {@link DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE}.
+     */
+    DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE = 'dashboard_custom_widget_options_update',
+    GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS = 'get_dashboard_custom_widget_options'
 }
 
 // These event types are always allowed, regardless of what features have been enabled

--- a/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.test.ts
+++ b/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.test.ts
@@ -1,10 +1,169 @@
-import { FeatureType, WidgetOptionItemType } from '../../constants';
-import { Context } from '../../types';
+import {
+    FeatureType,
+    RequestType,
+    WidgetOptionItemType
+} from '../../constants';
+import { Context, GetDashboardCustomWidgetOptionsResponse } from '../../types';
 import { MockClient, mockContext } from '../../utils/testUtils';
+import { GetDashboardCustomWidgetOptionsRequest } from '../..';
 
 import { DDDashboardCustomWidgetClient } from './dashboard-custom-widget';
 
 describe('DDDashboardCustomWidgetClient', () => {
+    describe('onOptionsRequest', () => {
+        test('throws an error if `DASHBOARD_CUSTOM_WIDGET` is not enabled', async () => {
+            const client = new MockClient();
+            const context: Context = {
+                ...mockContext,
+                app: {
+                    ...mockContext.app,
+                    features: []
+                }
+            };
+            client.framePostClient.init(context);
+            const dashboardCustomWidgetClient = new DDDashboardCustomWidgetClient(
+                client
+            );
+            const handler = jest.fn<
+                GetDashboardCustomWidgetOptionsResponse,
+                [GetDashboardCustomWidgetOptionsRequest]
+            >(() => {
+                return {
+                    options: [
+                        {
+                            type: WidgetOptionItemType.BOOLEAN,
+                            label: 'option',
+                            name: 'option'
+                        }
+                    ]
+                };
+            });
+            dashboardCustomWidgetClient.onOptionsRequest(handler);
+
+            const response = client.framePostClient.mockRequest(
+                RequestType.GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS,
+                { widget: { definition: { custom_widget_key: 'key' } } }
+            );
+
+            await expect(response).rejects.toBeInstanceOf(Error);
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        test('registers an empty handler on init', async () => {
+            const client = new MockClient();
+            const context: Context = {
+                ...mockContext,
+                app: {
+                    ...mockContext.app,
+                    features: [FeatureType.DASHBOARD_CUSTOM_WIDGET]
+                }
+            };
+            client.framePostClient.init(context);
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const dashboardCustomWidgetClient = new DDDashboardCustomWidgetClient(
+                client
+            );
+
+            const response = client.framePostClient.mockRequest(
+                RequestType.GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS,
+                { widget: { definition: { custom_widget_key: 'key' } } }
+            );
+
+            await expect(response).resolves.toEqual({ options: [] });
+        });
+
+        test('registers the provided handler when onOptionsRequest is called', async () => {
+            const client = new MockClient();
+            const context: Context = {
+                ...mockContext,
+                app: {
+                    ...mockContext.app,
+                    features: [FeatureType.DASHBOARD_CUSTOM_WIDGET]
+                }
+            };
+            client.framePostClient.init(context);
+            const dashboardCustomWidgetClient = new DDDashboardCustomWidgetClient(
+                client
+            );
+            const handler = jest.fn<
+                GetDashboardCustomWidgetOptionsResponse,
+                [GetDashboardCustomWidgetOptionsRequest]
+            >(() => {
+                return {
+                    options: [
+                        {
+                            type: WidgetOptionItemType.BOOLEAN,
+                            label: 'option',
+                            name: 'option'
+                        }
+                    ]
+                };
+            });
+            dashboardCustomWidgetClient.onOptionsRequest(handler);
+
+            const response = client.framePostClient.mockRequest(
+                RequestType.GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS,
+                { widget: { definition: { custom_widget_key: 'key' } } }
+            );
+
+            await expect(response).resolves.toEqual({
+                options: [
+                    {
+                        type: WidgetOptionItemType.BOOLEAN,
+                        label: 'option',
+                        name: 'option'
+                    }
+                ]
+            });
+            expect(handler).toHaveBeenCalledWith({
+                widget: { definition: { custom_widget_key: 'key' } }
+            });
+        });
+
+        test('returns an unsubscribe hook that replaces with an empty handler', async () => {
+            const client = new MockClient();
+            const context: Context = {
+                ...mockContext,
+                app: {
+                    ...mockContext.app,
+                    features: [FeatureType.DASHBOARD_CUSTOM_WIDGET]
+                }
+            };
+            client.framePostClient.init(context);
+            const dashboardCustomWidgetClient = new DDDashboardCustomWidgetClient(
+                client
+            );
+            const handler = jest.fn<
+                GetDashboardCustomWidgetOptionsResponse,
+                [GetDashboardCustomWidgetOptionsRequest]
+            >(() => {
+                return {
+                    options: [
+                        {
+                            type: WidgetOptionItemType.BOOLEAN,
+                            label: 'option',
+                            name: 'option'
+                        }
+                    ]
+                };
+            });
+            const unsubscribe = dashboardCustomWidgetClient.onOptionsRequest(
+                handler
+            );
+
+            unsubscribe();
+            const response = client.framePostClient.mockRequest(
+                RequestType.GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS,
+                { widget: { definition: { custom_widget_key: 'key' } } }
+            );
+
+            await expect(response).resolves.toEqual({
+                options: []
+            });
+            expect(handler).not.toHaveBeenCalled();
+        });
+    });
+
     describe('updateOptions', () => {
         test('does not sends a request if there is no widget', async () => {
             const client = new MockClient();

--- a/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
+++ b/packages/ui-extensions-sdk/src/dashboard/dashboard-custom-widget/dashboard-custom-widget.ts
@@ -2,16 +2,81 @@ import { RequestType, FeatureType } from '../../constants';
 import { DDFeatureClient } from '../../shared/feature-client';
 import type {
     ContextClient,
+    GetDashboardCustomWidgetOptionsRequest,
+    GetDashboardCustomWidgetOptionsResponse,
     LoggerClient,
     RequestClient,
     WidgetOptionItem
 } from '../../types';
 
+const emptyResponse: GetDashboardCustomWidgetOptionsResponse = {
+    options: []
+};
+
 export class DDDashboardCustomWidgetClient extends DDFeatureClient {
     constructor(client: ContextClient & LoggerClient & RequestClient) {
         super(client, FeatureType.DASHBOARD_CUSTOM_WIDGET);
+
+        this.onOptionsRequest(() => emptyResponse);
     }
 
+    /**
+     * Registers a request handler for providing custom widget options dynamically.
+     * This should only be used in the controller.
+     *
+     * @param requestHandler The callback that responds to requests for custom widget options.
+     * @since 0.28.0
+     *
+     * @example
+     * In the controller:
+     * ```TypeScript
+     * import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+     *
+     * export function setup() {
+     *     const client = uiExtensionsSDK.init();
+     *     client.dashboard.customWidget.onOptionsRequest(
+     *         (
+     *             request: uiExtensionsSDK.GetDashboardCustomWidgetOptionsRequest
+     *         ): uiExtensionsSDK.GetDashboardCustomWidgetOptionsResponse => {
+     *             return {
+     *                 options: [
+     *                     {
+     *                         type: uiExtensionsSDK.WidgetOptionItemType.BOOLEAN,
+     *                         name: 'option-1',
+     *                         label: 'Enable option 1?',
+     *                     },
+     *                     {
+     *                         type: uiExtensionsSDK.WidgetOptionItemType.BOOLEAN,
+     *                         name: 'option-2',
+     *                         label: 'Enable option 2?',
+     *                     }
+     *                 ]
+     *             };
+     *         }
+     *     );
+     * }
+     * ```
+     */
+    onOptionsRequest(
+        requestHandler: (
+            request: GetDashboardCustomWidgetOptionsRequest
+        ) =>
+            | GetDashboardCustomWidgetOptionsResponse
+            | Promise<GetDashboardCustomWidgetOptionsResponse>
+    ) {
+        this.handleRequest(
+            RequestType.GET_DASHBOARD_CUSTOM_WIDGET_OPTIONS,
+            requestHandler
+        );
+
+        return () => {
+            this.onOptionsRequest(() => emptyResponse);
+        };
+    }
+
+    /**
+     * @deprecated Use {@link onOptionsRequest} in the controller instead of {@link updateOptions} in the widget.
+     */
     async updateOptions(newOptions: WidgetOptionItem[]) {
         const { widget } = await this.getContext();
         if (widget?.definition && widget?.id) {

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -302,6 +302,16 @@ export interface CustomWidgetItem {
     icon?: string;
 }
 
+export interface GetDashboardCustomWidgetOptionsRequest {
+    widget: Omit<DashboardWidgetContext, 'definition'> & {
+        definition: CustomWidgetDefinition;
+    };
+}
+
+export interface GetDashboardCustomWidgetOptionsResponse {
+    options: WidgetOptionItem[];
+}
+
 // Payload of event broadcast when oauth access is updated
 export interface APIAccessChangeEvent {
     isAuthorized: boolean;


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- Jira Issue: https://datadoghq.atlassian.net/browse/UIAPPS-90
- We want to support handling requests for custom widget dynamic options. The changeset details more of what we're doing, but the long and short is that we move from the App developer being in control of dynamic options to the App developer responding to requests for dynamic options. This is more in line with how other dynamic behavior works and allows us to provide a better experience in the end.

<!-- - Is this a bugfix or a feature? -->

## Changes

- We add an "onRequest" method for custom widget dynamic options.
- We mark the old `DDDashboardCustomWidgetClient.updateOptions` as deprecated.
- We update the docs to talk about the new way.

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [x] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/ui-extensions-sdk@0.27.2-canary.107.df89b88.0
  # or 
  yarn add @datadog/ui-extensions-sdk@0.27.2-canary.107.df89b88.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
