### PR TITLE
UIAPPS-152 Add `useTemplateVariable` hook

### DIFF
--- a/.changeset/pretty-dingos-learn.md
+++ b/.changeset/pretty-dingos-learn.md
@@ -1,0 +1,15 @@
+---
+'@datadog/ui-extensions-react': patch
+---
+
+Add a react hook (`useTemplateVariable`) for working template variables.
+
+Dealing with template variables can be a bit difficult to get right.
+You have to at least:
+grab the initial variables from the context,
+listen for changes to the context,
+unsubscribe from event changes when unmounted,
+and search through all the template variables to find the one you're looking for.
+
+This new `useCustomWidgetOptions` hook hopefully makes that easier.
+It manages all the intricacies of dealing with template variables so the App can focus on the logic that's important.

--- a/examples/geomap/datadog-app/package.json
+++ b/examples/geomap/datadog-app/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.0",
     "private": true,
     "dependencies": {
+        "@datadog/ui-extensions-react": "0.27.1",
         "@datadog/ui-extensions-sdk": "0.27.1",
         "@types/node": "^14.14.14",
         "@types/react": "^17.0.0",

--- a/examples/geomap/datadog-app/src/widget/GeoMap/index.tsx
+++ b/examples/geomap/datadog-app/src/widget/GeoMap/index.tsx
@@ -1,9 +1,6 @@
+import { useTemplateVariable } from '@datadog/ui-extensions-react';
 import { Map, Marker } from 'pigeon-maps';
-import {
-    init,
-    EventType,
-    TemplateVariableValue
-} from '@datadog/ui-extensions-sdk';
+import { init } from '@datadog/ui-extensions-sdk';
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -19,47 +16,18 @@ interface Location {
 
 function Widget() {
     const [location, setLocation] = useState<Location | null>(null);
-    const [ip, setIp] = useState<string[] | []>([]);
+    const ipAddress = useTemplateVariable(client, 'IP');
 
     useEffect(() => {
-        if (!ip.length) return;
+        if (!ipAddress) return;
 
-        const [ipAddress] = ip;
         fetch(`${API_URL}?ip=${ipAddress}`)
             .then(res => res.json())
             .then(({ geo: { latitude, longitude } }) =>
                 setLocation({ latitude, longitude })
             )
             .catch(err => console.log(`An error occurs`, err));
-    }, [ip]);
-
-    useEffect(() => {
-        client
-            .getContext()
-            //.then(context => console.log(context.dashboard?.templateVars))
-            .then(({ dashboard }) =>
-                handleTemplateVariables(dashboard?.templateVars)
-            );
-    }, []);
-
-    useEffect(() => {
-        client.events.on(EventType.CONTEXT_CHANGE, ({ dashboard }) => {
-            handleTemplateVariables(dashboard?.templateVars);
-        });
-    }, []);
-
-    const handleTemplateVariables = (
-        templateVariables: undefined | TemplateVariableValue[]
-    ) => {
-        if (templateVariables === undefined || !templateVariables.length)
-            return;
-
-        const newIp = templateVariables
-            .filter(variable => variable.name === 'IP')
-            .map(variable => variable.value);
-
-        setIp(newIp);
-    };
+    }, [ipAddress]);
 
     if (!location) return <div>Loading...</div>;
 

--- a/packages/ui-extensions-react/src/index.ts
+++ b/packages/ui-extensions-react/src/index.ts
@@ -1,1 +1,2 @@
 export * from './use-context';
+export * from './use-template-variable';

--- a/packages/ui-extensions-react/src/use-template-variable.test.ts
+++ b/packages/ui-extensions-react/src/use-template-variable.test.ts
@@ -1,0 +1,208 @@
+import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+import * as reactHooks from '@testing-library/react-hooks';
+
+import { useTemplateVariable } from './use-template-variable';
+
+/**
+ * Lifted from `@datadog/ui-extensions-sdk/src/utils/testUtils`.
+ */
+interface Deferred<Value> {
+    promise: Promise<Value>;
+    reject: (t: unknown) => void;
+    resolve: (t: Value) => void;
+}
+
+/**
+ * Lifted from `@datadog/ui-extensions-sdk/src/utils/testUtils`.
+ */
+const defer = <Value>(): Deferred<Value> => {
+    let reject: (error: unknown) => void = () => {};
+    let resolve: (value: Value) => void = () => {};
+    const promise = new Promise<Value>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return {
+        promise,
+        reject,
+        resolve
+    };
+};
+
+let deferredContext: Deferred<uiExtensionsSDK.Context>;
+let handler: (eventData: unknown) => void;
+
+const makeContext = (
+    templateVars: uiExtensionsSDK.TemplateVariableValue[]
+): uiExtensionsSDK.Context => {
+    return {
+        app: {
+            currentUser: {
+                colorTheme: uiExtensionsSDK.ColorTheme.light,
+                timeZone: ''
+            },
+            debug: false,
+            features: []
+        },
+        dashboard: {
+            id: '',
+            shareURL: '',
+            templateVars,
+            timeframe: {
+                end: 0,
+                isLive: false,
+                start: 0
+            }
+        }
+    };
+};
+
+const onUnsubscribe = jest.fn<void, never[]>();
+
+jest.mock('@datadog/ui-extensions-sdk', () => {
+    return {
+        ...jest.requireActual<object>('@datadog/ui-extensions-sdk'),
+        DDClient: jest.fn(() => {
+            return {
+                events: {
+                    on: jest.fn(
+                        (
+                            eventType: uiExtensionsSDK.EventType,
+                            callback: (eventData: unknown) => void
+                        ): (() => void) => {
+                            if (
+                                eventType !==
+                                uiExtensionsSDK.EventType.CONTEXT_CHANGE
+                            ) {
+                                return () => {};
+                            }
+
+                            handler = callback;
+                            return onUnsubscribe;
+                        }
+                    )
+                },
+                getContext: jest.fn(
+                    (): Promise<uiExtensionsSDK.Context> => {
+                        return deferredContext.promise;
+                    }
+                )
+            };
+        })
+    };
+});
+
+beforeEach((): void => {
+    deferredContext = defer();
+    handler = (eventData: unknown): void => {};
+    jest.clearAllMocks();
+});
+
+describe('useTemplateVariable', (): void => {
+    test('returns `undefined` if the variable is not set', (): void => {
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useTemplateVariable(client, 'variable1');
+        });
+
+        expect(result.result.current).toEqual(undefined);
+    });
+
+    test('returns the value from the initial context', async (): Promise<
+        void
+    > => {
+        const context: uiExtensionsSDK.Context = makeContext([
+            {
+                name: 'variable1',
+                value: 'value1'
+            }
+        ]);
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useTemplateVariable(client, 'variable1');
+        });
+        await reactHooks.act(
+            async (): Promise<void> => {
+                deferredContext.resolve(context);
+                await result.waitForNextUpdate();
+            }
+        );
+
+        expect(result.result.current).toEqual('value1');
+    });
+
+    test('updates from the `CONTEXT_CHANGE` event', async (): Promise<void> => {
+        const client = new uiExtensionsSDK.DDClient();
+        const context: uiExtensionsSDK.Context = makeContext([
+            {
+                name: 'variable1',
+                value: 'value1'
+            }
+        ]);
+
+        const result = reactHooks.renderHook(() => {
+            return useTemplateVariable(client, 'variable1');
+        });
+        await reactHooks.act(
+            async (): Promise<void> => {
+                handler(context);
+                await result.waitForNextUpdate();
+            }
+        );
+
+        expect(result.result.current).toEqual('value1');
+    });
+
+    test('uses latest value from the `CONTEXT_CHANGE` event', async (): Promise<
+        void
+    > => {
+        const client = new uiExtensionsSDK.DDClient();
+        const context1: uiExtensionsSDK.Context = makeContext([
+            {
+                name: 'variable1',
+                value: 'value1'
+            }
+        ]);
+        const context2: uiExtensionsSDK.Context = makeContext([
+            {
+                name: 'variable1',
+                value: 'value2'
+            }
+        ]);
+
+        const result = reactHooks.renderHook(() => {
+            return useTemplateVariable(client, 'variable1');
+        });
+        await reactHooks.act(
+            async (): Promise<void> => {
+                handler(context1);
+                await result.waitForNextUpdate();
+            }
+        );
+        await reactHooks.act(
+            async (): Promise<void> => {
+                handler(context2);
+                await result.waitForNextUpdate();
+            }
+        );
+
+        expect(result.result.current).toEqual('value2');
+    });
+
+    test('invokes unsubscribe callback when unmounting', (): void => {
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useTemplateVariable(client, 'variable1');
+        });
+
+        expect(onUnsubscribe).not.toHaveBeenCalled();
+
+        result.unmount();
+
+        expect(onUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/ui-extensions-react/src/use-template-variable.ts
+++ b/packages/ui-extensions-react/src/use-template-variable.ts
@@ -1,0 +1,55 @@
+import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+import * as React from 'react';
+
+import * as useContext from './use-context';
+
+/**
+ * Returns the current value of a specific template variable.
+ * This will be updated whenever the template variable change.
+ *
+ * This hook abstracts away the intricacies of keeping template variables up to date.
+ *
+ * @param client An initialized {@link uiExtensionsSDK.DDClient}. This should be the result of invoking {@link uiExtensionsSDK.init}.
+ * @param variableName The name of the template variable to get the value of.
+ * @returns The value of the template variable if it exists.
+ *
+ * @example
+ * This hook can be used like:
+ * ```TypeScript
+ * import * as uiExtensionsReact from '@datadog/ui-extensions-react';
+ * import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+ * import * as React from 'react';
+ *
+ * const client = uiExtensionsSDK.init();
+ *
+ * const CustomWidget: React.FunctionComponent = () => {
+ *     const service = uiExtensionsReact.useTemplateVariable(client, 'service');
+ *
+ *     if (service == null) {
+ *         return <p>Please select a service from the template variables.</p>;
+ *     }
+ *
+ *     return <p>Service: {service}.</p>;
+ * }
+ * ```
+ */
+function useTemplateVariable(
+    client: uiExtensionsSDK.DDClient,
+    variableName: string
+): string | undefined {
+    const context = useContext.useContext(client);
+
+    const variable = React.useMemo(() => {
+        const templateVariable = context?.dashboard?.templateVars.find(
+            (value: uiExtensionsSDK.TemplateVariableValue): boolean => {
+                return value.name === variableName;
+            }
+        );
+
+        return templateVariable?.value;
+    }, [context?.dashboard?.templateVars, variableName]);
+
+    return variable;
+}
+
+export { useTemplateVariable };

--- a/packages/ui-extensions-react/src/use-template-variable.ts
+++ b/packages/ui-extensions-react/src/use-template-variable.ts
@@ -3,6 +3,23 @@ import * as React from 'react';
 
 import * as useContext from './use-context';
 
+function findTemplateVariableValue(
+    variableName: string,
+    templateVariables: uiExtensionsSDK.TemplateVariableValue[]
+): string | undefined {
+    const templateVariable = templateVariables.find(
+        (value: uiExtensionsSDK.TemplateVariableValue): boolean => {
+            return value.name === variableName;
+        }
+    );
+
+    if (templateVariable?.value == null) {
+        return;
+    }
+
+    return templateVariable.value;
+}
+
 /**
  * Returns the current value of a specific template variable.
  * This will be updated whenever the template variable change.
@@ -41,17 +58,16 @@ function useTemplateVariable(
     const [variable, setVariable] = React.useState<string | undefined>();
 
     React.useEffect(() => {
-        const templateVariable = context?.dashboard?.templateVars.find(
-            (value: uiExtensionsSDK.TemplateVariableValue): boolean => {
-                return value.name === variableName;
-            }
+        const templateVariables = context?.dashboard?.templateVars ?? [];
+        const value = findTemplateVariableValue(
+            variableName,
+            templateVariables
         );
-
-        if (templateVariable?.value == null) {
+        if (value == null) {
             return;
         }
 
-        setVariable(templateVariable.value);
+        setVariable(value);
     }, [context?.dashboard?.templateVars, variableName]);
 
     React.useEffect(() => {
@@ -60,17 +76,15 @@ function useTemplateVariable(
             (
                 templateVariables: uiExtensionsSDK.TemplateVariableValue[]
             ): void => {
-                const templateVariable = templateVariables.find(
-                    (value: uiExtensionsSDK.TemplateVariableValue): boolean => {
-                        return value.name === variableName;
-                    }
+                const value = findTemplateVariableValue(
+                    variableName,
+                    templateVariables
                 );
-
-                if (templateVariable?.value == null) {
+                if (value == null) {
                     return;
                 }
 
-                setVariable(templateVariable.value);
+                setVariable(value);
             }
         );
 

--- a/packages/ui-extensions-react/src/use-template-variable.ts
+++ b/packages/ui-extensions-react/src/use-template-variable.ts
@@ -22,7 +22,7 @@ function findTemplateVariableValue(
 
 /**
  * Returns the current value of a specific template variable.
- * This will be updated whenever the template variable change.
+ * This will be updated whenever the template variable changes.
  *
  * This hook abstracts away the intricacies of keeping template variables up to date.
  *


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- Jira Issue: https://datadoghq.atlassian.net/browse/UIAPPS-152
- Much like the `useContext` hook did for `Context`, we want to abstract away some of the intricacies of dealing with template variables. It can be hard to get right, so we want a hook that makes it easier to do the right thing.

<!-- - Is this a bugfix or a feature? -->

## Changes

- We add a new `useTemplateVariable` hook that makes it easier to work with template variables.
- We also update the example geomap App to use this new hook.

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

- We added a suite of tests for this hook, so we should catch the majority of issues.

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [x] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/ui-extensions-react@0.27.2-canary.109.e1896ad.0
  npm install @datadog/ui-extensions-sdk@0.27.2-canary.109.e1896ad.0
  # or 
  yarn add @datadog/ui-extensions-react@0.27.2-canary.109.e1896ad.0
  yarn add @datadog/ui-extensions-sdk@0.27.2-canary.109.e1896ad.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
