### PR TITLE
Notifications

### DIFF
--- a/.changeset/cool-avocados-play.md
+++ b/.changeset/cool-avocados-play.md
@@ -1,0 +1,5 @@
+---
+'@datadog/ui-extensions-react': minor
+---
+
+Notifications

--- a/.changeset/grumpy-falcons-dance.md
+++ b/.changeset/grumpy-falcons-dance.md
@@ -1,0 +1,5 @@
+---
+'@datadog/ui-extensions-sdk': patch
+---
+
+Add notification hook

--- a/docs/en/programming-model.md
+++ b/docs/en/programming-model.md
@@ -175,7 +175,7 @@ client.notification.send({
 })
 ```
 
-Notifications may optionally include a 'level' indicating notification severity. Available levels are `success`, `warning`, and `danger`. This is particularly useful for reporting success and failure of asyncrhronous actions:
+Notifications may optionally include a 'level' indicating notification severity. Available levels are `success`, `warning`, and `danger`. This is particularly useful for reporting success and failure of asynchronous actions:
 
 ```js
 try {

--- a/docs/en/programming-model.md
+++ b/docs/en/programming-model.md
@@ -164,6 +164,37 @@ client.location.goTo('/infrastructure/map');
 
 In addition, apps may open new tabs with `target=”\_\_blank”` links.
 
+### Notifications
+
+The SDK provides a hook for sending user notifications. This is useful for general communication outside of specific UI Extension features. The notifications are transient and are not shared between user sessions:
+
+```js
+// Standard format:
+client.notification.send({
+  label: 'Please read this thing!'
+})
+```
+
+Notifications may optionally include a 'level' indicating notification severity. Available levels are `success`, `warning`, and `danger`. This is particularly useful for reporting success and failure of asyncrhronous actions:
+
+```js
+try {
+  await submitReport(report);
+
+  client.notification.send({
+    label: 'Report submitted',
+    level: 'success'
+  })
+} catch (e) {
+  client.notification.send({
+    label: 'Failed to submit, please try again.',
+    level: 'danger'
+  })
+}
+```
+
+
+
 # UI Extensions
 
 ## Dashboard Custom Widget

--- a/packages/ui-extensions-sdk/src/client/client.ts
+++ b/packages/ui-extensions-sdk/src/client/client.ts
@@ -7,6 +7,7 @@ import { DDDashboardClient } from '../dashboard/dashboard';
 import { DDEventsClient } from '../events/events';
 import { DDLocationClient } from '../location/location';
 import { DDModalClient } from '../modal/modal';
+import { DDNotificationClient } from '../notification/notification';
 import { DDSidePanelClient } from '../side-panel/side-panel';
 import type {
     ClientContext,
@@ -37,7 +38,8 @@ export class DDClient<AuthStateArgs = unknown>
         DebugClient,
         EventClient,
         LoggerClient,
-        RequestClient {
+        RequestClient
+{
     private context?: Context | null;
     private readonly framePostClient: ChildClient<Context>;
     private readonly logger: Logger;
@@ -47,6 +49,7 @@ export class DDClient<AuthStateArgs = unknown>
     events: DDEventsClient<AuthStateArgs>;
     location: DDLocationClient;
     modal: DDModalClient;
+    notification: DDNotificationClient;
     sidePanel: DDSidePanelClient;
     widgetContextMenu: DDWidgetContextMenuClient;
     auth: DDAuthClient<AuthStateArgs>;
@@ -85,6 +88,7 @@ export class DDClient<AuthStateArgs = unknown>
         this.dashboard = new DDDashboardClient(this);
         this.location = new DDLocationClient(this);
         this.modal = new DDModalClient(this);
+        this.notification = new DDNotificationClient(this);
         this.sidePanel = new DDSidePanelClient(this);
         this.widgetContextMenu = new DDWidgetContextMenuClient(this);
 

--- a/packages/ui-extensions-sdk/src/client/client.ts
+++ b/packages/ui-extensions-sdk/src/client/client.ts
@@ -38,8 +38,7 @@ export class DDClient<AuthStateArgs = unknown>
         DebugClient,
         EventClient,
         LoggerClient,
-        RequestClient
-{
+        RequestClient {
     private context?: Context | null;
     private readonly framePostClient: ChildClient<Context>;
     private readonly logger: Logger;

--- a/packages/ui-extensions-sdk/src/constants.ts
+++ b/packages/ui-extensions-sdk/src/constants.ts
@@ -81,7 +81,10 @@ export enum RequestType {
     SET_DASHBOARD_CURSOR = 'set_dashboard_cursor',
 
     // Widgets
-    DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE = 'dashboard_custom_widget_options_update'
+    DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE = 'dashboard_custom_widget_options_update',
+
+    // Notifications
+    SEND_NOTIFICATION = 'send_notification'
 }
 
 // These event types are always allowed, regardless of what features have been enabled

--- a/packages/ui-extensions-sdk/src/notification/notification.test.ts
+++ b/packages/ui-extensions-sdk/src/notification/notification.test.ts
@@ -1,0 +1,40 @@
+import { FeatureType, RequestType } from '../constants';
+import { mockContext, MockClient } from '../utils/testUtils';
+
+import { DDNotificationClient } from './notification';
+
+let client: MockClient;
+let notificationClient: DDNotificationClient;
+
+beforeEach(() => {
+    client = new MockClient();
+    notificationClient = new DDNotificationClient(client as any);
+});
+
+describe('notification.send()', () => {
+    test('sends an open request with definition to parent', async () => {
+        client.framePostClient.init({
+            ...mockContext,
+            app: {
+                ...mockContext.app,
+                features: [FeatureType.SIDE_PANELS]
+            }
+        });
+        const requestMock = jest
+            .spyOn(client.framePostClient, 'request')
+            .mockImplementation(() => null);
+
+        await notificationClient.send({
+            label: 'You screwed up bad!',
+            level: 'danger'
+        });
+
+        expect(requestMock).toHaveBeenCalledWith(
+            RequestType.SEND_NOTIFICATION,
+            {
+                label: 'You screwed up bad!',
+                level: 'danger'
+            }
+        );
+    });
+});

--- a/packages/ui-extensions-sdk/src/notification/notification.ts
+++ b/packages/ui-extensions-sdk/src/notification/notification.ts
@@ -1,0 +1,17 @@
+import { RequestType } from '../constants';
+import { RequestClient, NotificationDefinition } from '../types';
+
+export class DDNotificationClient {
+    private readonly client: RequestClient;
+
+    constructor(client: RequestClient) {
+        this.client = client;
+    }
+
+    async send(definition: NotificationDefinition) {
+        return this.client.request<NotificationDefinition, void>(
+            RequestType.SEND_NOTIFICATION,
+            definition
+        );
+    }
+}

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -246,14 +246,13 @@ export type ParentAuthStateOptions = {
     | AuthStateOptionsCloseResolution
 );
 
-export type AuthStateOptions<
-    AuthStateArgs = unknown
-> = ParentAuthStateOptions & {
-    authStateCallback: () =>
-        | Promise<AuthState<AuthStateArgs> | boolean>
-        | AuthState<AuthStateArgs>
-        | boolean;
-};
+export type AuthStateOptions<AuthStateArgs = unknown> =
+    ParentAuthStateOptions & {
+        authStateCallback: () =>
+            | Promise<AuthState<AuthStateArgs> | boolean>
+            | AuthState<AuthStateArgs>
+            | boolean;
+    };
 
 interface WidgetOptionEnum {
     label: string;
@@ -322,7 +321,13 @@ export interface IFrameDimensions {
  */
 type RequireKeys<T, K extends keyof T> = {
     [X in Exclude<keyof T, K>]?: T[X];
-} &
-    {
-        [P in K]-?: T[P];
-    };
+} & {
+    [P in K]-?: T[P];
+};
+
+export type NotificationLevel = 'success' | 'warning' | 'danger';
+
+export interface NotificationDefinition {
+    label: string;
+    level?: NotificationLevel;
+}

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -246,13 +246,14 @@ export type ParentAuthStateOptions = {
     | AuthStateOptionsCloseResolution
 );
 
-export type AuthStateOptions<AuthStateArgs = unknown> =
-    ParentAuthStateOptions & {
-        authStateCallback: () =>
-            | Promise<AuthState<AuthStateArgs> | boolean>
-            | AuthState<AuthStateArgs>
-            | boolean;
-    };
+export type AuthStateOptions<
+    AuthStateArgs = unknown
+> = ParentAuthStateOptions & {
+    authStateCallback: () =>
+        | Promise<AuthState<AuthStateArgs> | boolean>
+        | AuthState<AuthStateArgs>
+        | boolean;
+};
 
 interface WidgetOptionEnum {
     label: string;
@@ -321,9 +322,10 @@ export interface IFrameDimensions {
  */
 type RequireKeys<T, K extends keyof T> = {
     [X in Exclude<keyof T, K>]?: T[X];
-} & {
-    [P in K]-?: T[P];
-};
+} &
+    {
+        [P in K]-?: T[P];
+    };
 
 export type NotificationLevel = 'success' | 'warning' | 'danger';
 


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

Developers need a way to alert users when async things happen, including success and failure of actions. This does that!

## Changes

- Adds a 'notification' hook to the sdk, for popping toasts in front of the user
- Documents new notification hook

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/ui-extensions-sdk@0.28.1-canary.112.cd0d8df.0
  # or 
  yarn add @datadog/ui-extensions-sdk@0.28.1-canary.112.cd0d8df.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
