### PR TITLE
Deprecate dashboard_timeframe_change and dashboard_template_var_change events

### DIFF
--- a/.changeset/fifty-spoons-drum.md
+++ b/.changeset/fifty-spoons-drum.md
@@ -1,0 +1,6 @@
+---
+'@datadog/ui-extensions-sdk': minor
+'@datadog/ui-extensions-react': minor
+---
+
+Deprecate granular dashboard change events in favor of context_change

--- a/docs/en/programming-model.md
+++ b/docs/en/programming-model.md
@@ -49,29 +49,33 @@ Although there are no architectural requirements for how to structure your app, 
 
 ## Context Data
 
-**Context** data provides information about the global and specific setting in which features mount in the Datadog UI. Context data will be provided to the SDK in several different ways:
+**Context** data provides information about the global and specific setting in which features mount in the Datadog UI. For example, in a custom widget the configured widget options will be present at `context.widget.options`, and on a dashboard the current template variables will be provided at `context.dashboard.templateVars`. 
 
-- When an App IFrame mounts and successfully handshakes with the Datadog UI, it will receive a set of **context** data containing basic information about the setting in which the IFrame renders. This context Data can be accessed with client.getContext() on the SDK client:
+### Getting initial context data
+
+When an App IFrame mounts and successfully handshakes with the Datadog UI, it will receive the initial **context**. This data can be accessed with client.getContext() on the SDK client:
 
 ```js
 client.getContext().then((context) => {
-  ...
+  console.log(context.dashboard.templateVars)
 })
 ```
 
-- When the context sent to an IFrame changes, each frame will receive new context from the `context_change` event:
+### Responding to changing context
+
+In most cases apps will also need to listen for changing context. For example, the current dashboard timeframe may change as the user edits. Whenever any subset of an iFrame's context changes, the Frame will receive a `context_change` event containing updated information. This can be used to update local state, respond to changes in specific fields, and more. 
 
 ```
 client.events.on('context_change', (newContext) => {
- //
+ if (newContext.dashboard.templateVars !== oldContext.dashboard.templateVars) {
+
+ }
 });
 ```
 
-- When menu-items (cog menu items, context menu items, or others) are clicked, the SDK in all active iframes will receive a click event. In order to determine where the click event is in the app, click event handlers will receive another set of context data:
+As a convenience for React developers, we provide a lightweight [useContext](https://datadoghq.dev/apps/modules/_datadog_ui_extensions_react.html#useContext) hook which automatically provides live-updated context data for use in a React component. 
 
-```js
-client.events.on('dashboard_cog_menu_click', (clickContext) => {});
-```
+If there is interest in similar framework-specific wrappers please let us know. 
 
 **Context structure attributes**
 
@@ -106,12 +110,12 @@ Events allow the Datadog UI to communicate with App IFrames, and for App IFrames
 
 **Standard Events:**
 
-Datadog will send App IFrames events at relevant times in the lifecycle of the application. For example, custom widget iframes will receive a `dashboard_timeframe_change` event when dashboard timeframe changes. Other IFrames will receive events relevant to their use cases, in addition to any global events that may be relevant. These events can be subscribed to with `client.events.on()`:
+Datadog will send App IFrames events at relevant times in the lifecycle of the application. For example, custom widget iframes will receive a `dashboard_cursor_change` event as the user moves the cursor on a dashboard. Other IFrames will receive events relevant to their use cases, in addition to any global events that may be relevant. These events can be subscribed to with `client.events.on()`:
 
 ```js
 const unsubscribe = client.events.on(
-  'dashboard_timeframe_change',
-  (newoptions) => {}
+  'dashboard_cursor_change',
+  (newlocation) => {}
 );
 ```
 
@@ -332,8 +336,6 @@ const { app, dashboard, widget } = await client.getContext();
 Additionally, Custom widget iframes can subscribe to the following events:
 
 - `dashboard_custom_widget_options_change`: triggered when the widget is edited. Event handlers will receive an object with the updated configuration options of this widget.
-- `dashboard_timeframe_change`: triggered when the timeframe of the current dashboard changes. Event handlers will receive an object with the updated timeframe values.
-- `dashboard_template_var_change`: triggered when the template variables of the current dashboard change. Event handlers will receive an object with the updated template variables values.
 - `dashboard_cursor_change`: triggered when users mouse over charts on the dashboard. Can be used to track active timestamp across charts.
 
 ```js

--- a/docs/en/programming-model.md
+++ b/docs/en/programming-model.md
@@ -49,7 +49,7 @@ Although there are no architectural requirements for how to structure your app, 
 
 ## Context Data
 
-**Context** data provides information about the global and specific setting in which features mount in the Datadog UI. For example, in a custom widget the configured widget options will be present at `context.widget.options`, and on a dashboard the current template variables will be provided at `context.dashboard.templateVars`. 
+**Context** data provides information about the global and specific setting in which features mount in the Datadog UI. For example, in a custom widget the configured widget options will be present at `context.widget.options`, and on a dashboard (both for custom widgets and dashboard menu item features), the current template variables will be provided at `context.dashboard.templateVars`. 
 
 ### Getting initial context data
 
@@ -67,8 +67,10 @@ In most cases apps will also need to listen for changing context. For example, t
 
 ```
 client.events.on('context_change', (newContext) => {
- if (newContext.dashboard.templateVars !== oldContext.dashboard.templateVars) {
+ setTemplateVars(newContext.dashboard.templateVars);
 
+ if (!deepEquals(newContext.widget.options !== oldContext.widget.options)) {
+   // handle options change
  }
 });
 ```

--- a/packages/ui-extensions-react/src/use-template-variable.test.ts
+++ b/packages/ui-extensions-react/src/use-template-variable.test.ts
@@ -237,57 +237,5 @@ describe('useTemplateVariable', (): void => {
 
             expect(result.result.current).toEqual('value1');
         });
-
-        test('uses latest value from the event', async (): Promise<void> => {
-            const client = new uiExtensionsSDK.DDClient();
-            const context1: uiExtensionsSDK.Context = makeContext([
-                {
-                    name: 'variable1',
-                    value: 'value1'
-                }
-            ]);
-            const context2: uiExtensionsSDK.Context = makeContext([
-                {
-                    name: 'variable1',
-                    value: 'value2'
-                }
-            ]);
-
-            const result = reactHooks.renderHook(() => {
-                return useTemplateVariable(client, 'variable1');
-            });
-            await reactHooks.act(
-                async (): Promise<void> => {
-                    handlerContextChange(context1);
-                    await result.waitForNextUpdate();
-                }
-            );
-            await reactHooks.act(
-                async (): Promise<void> => {
-                    handlerContextChange(context2);
-                    await result.waitForNextUpdate();
-                }
-            );
-
-            expect(result.result.current).toEqual('value2');
-        });
-
-        test('invokes unsubscribe callback when unmounting', (): void => {
-            const client = new uiExtensionsSDK.DDClient();
-
-            const result = reactHooks.renderHook(() => {
-                return useTemplateVariable(client, 'variable1');
-            });
-
-            expect(
-                onUnsubscribeDashboardTemplateVarChange
-            ).not.toHaveBeenCalled();
-
-            result.unmount();
-
-            expect(
-                onUnsubscribeDashboardTemplateVarChange
-            ).toHaveBeenCalledTimes(1);
-        });
     });
 });

--- a/packages/ui-extensions-react/src/use-template-variable.ts
+++ b/packages/ui-extensions-react/src/use-template-variable.ts
@@ -70,29 +70,6 @@ function useTemplateVariable(
         setVariable(value);
     }, [context?.dashboard?.templateVars, variableName]);
 
-    React.useEffect(() => {
-        const unsubscribe = client.events.on(
-            uiExtensionsSDK.EventType.DASHBOARD_TEMPLATE_VAR_CHANGE,
-            (
-                templateVariables: uiExtensionsSDK.TemplateVariableValue[]
-            ): void => {
-                const value = findTemplateVariableValue(
-                    variableName,
-                    templateVariables
-                );
-                if (value == null) {
-                    return;
-                }
-
-                setVariable(value);
-            }
-        );
-
-        return () => {
-            unsubscribe();
-        };
-    }, [client.events, variableName]);
-
     return variable;
 }
 

--- a/packages/ui-extensions-sdk/src/client/client.ts
+++ b/packages/ui-extensions-sdk/src/client/client.ts
@@ -108,6 +108,10 @@ export class DDClient<AuthStateArgs = unknown>
         return this.logger.log(message);
     }
 
+    logWarning(message: string): void {
+        return this.logger.warn(message);
+    }
+
     logError(message: string): void {
         return this.logger.error(message);
     }

--- a/packages/ui-extensions-sdk/src/constants.ts
+++ b/packages/ui-extensions-sdk/src/constants.ts
@@ -84,7 +84,9 @@ export enum RequestType {
     DASHBOARD_CUSTOM_WIDGET_OPTIONS_UPDATE = 'dashboard_custom_widget_options_update',
 
     // Notifications
-    SEND_NOTIFICATION = 'send_notification'
+    SEND_NOTIFICATION = 'send_notification',
+
+    LOG_DEPRECATED_USAGE = 'log_deprecated_usage'
 }
 
 // These event types are always allowed, regardless of what features have been enabled

--- a/packages/ui-extensions-sdk/src/events/events.test.ts
+++ b/packages/ui-extensions-sdk/src/events/events.test.ts
@@ -104,6 +104,21 @@ describe('events.on()', () => {
         logSpy.mockRestore();
         errorSpy.mockRestore();
     });
+
+    test('Logs a warning in debug mode when attempting to subscribe to a deprecated event', async () => {
+        const warnSpy = jest
+            .spyOn(console, 'warn')
+            .mockImplementation(() => {});
+
+        eventsClient.on(EventType.DASHBOARD_TIMEFRAME_CHANGE, () => {});
+        eventsClient.on(EventType.DASHBOARD_TEMPLATE_VAR_CHANGE, () => {});
+
+        mockClient.framePostClient.init();
+
+        await flushPromises();
+
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
 });
 
 describe('events.broadcast()', () => {

--- a/packages/ui-extensions-sdk/src/events/events.ts
+++ b/packages/ui-extensions-sdk/src/events/events.ts
@@ -78,8 +78,6 @@ export class DDEventsClient<AuthStateArgs = unknown> {
         eventType: K,
         handler: EventHandler<DDEventDataTypes<AuthStateArgs>[K]>
     ): () => void {
-        this.logDeprecationWarning(eventType);
-
         // first, immediately subscribe
         const unsubscribe = this.client.on(eventType, handler);
 
@@ -99,6 +97,8 @@ export class DDEventsClient<AuthStateArgs = unknown> {
                     this.client.logError(
                         `Your app does not have the required features enabled to respond to events of type ${eventType}.`
                     );
+                } else {
+                    this.logDeprecationWarning(eventType);
                 }
             })
             .catch(() => {});

--- a/packages/ui-extensions-sdk/src/events/events.ts
+++ b/packages/ui-extensions-sdk/src/events/events.ts
@@ -12,6 +12,7 @@ import type {
     ModalDefinition,
     RequestClient,
     SidePanelDefinition,
+    DeprecatedUsage,
     TemplateVariableValue,
     Timeframe,
     WidgetContextMenuClickData,
@@ -133,12 +134,23 @@ export class DDEventsClient<AuthStateArgs = unknown> {
         );
     }
 
-    private logDeprecationWarning(eventType: EventType) {
+    private async logDeprecationWarning(eventType: EventType) {
         // For now, an event is considered deprecated if it has a warning in the above index
         const warning = deprecationWarnings[eventType];
 
         if (warning) {
             this.client.logWarning(warning);
+            try {
+                await this.client.request<DeprecatedUsage, void>(
+                    RequestType.LOG_DEPRECATED_USAGE,
+                    {
+                        entity: 'event',
+                        eventType
+                    }
+                );
+            } catch (e) {
+                //
+            }
         }
     }
 }

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -27,6 +27,7 @@ export interface EventClient {
 
 export interface LoggerClient {
     log(message: string): void;
+    logWarning(message: string): void;
     logError(message: string): void;
 }
 

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -334,3 +334,10 @@ export interface NotificationDefinition {
     label: string;
     level?: NotificationLevel;
 }
+
+export interface DeprecatedEventUsage {
+    entity: 'event';
+    eventType: EventType;
+}
+
+export type DeprecatedUsage = DeprecatedEventUsage; // we can union type here later

--- a/packages/ui-extensions-sdk/src/utils/logger.ts
+++ b/packages/ui-extensions-sdk/src/utils/logger.ts
@@ -19,6 +19,12 @@ export class Logger {
         }
     }
 
+    warn(message: string) {
+        if (this.client.debug) {
+            return console.warn(`${this.getPrefix()}${message}`);
+        }
+    }
+
     error(message: string) {
         if (this.client.debug) {
             return console.error(`${this.getPrefix()}${message}`);

--- a/packages/ui-extensions-sdk/src/utils/testUtils.ts
+++ b/packages/ui-extensions-sdk/src/utils/testUtils.ts
@@ -51,7 +51,10 @@ export const mockContext: Context = {
             timeZone: 'America/New_York',
             colorTheme: ColorTheme.light
         },
-        features: [FeatureType.DASHBOARD_COG_MENU],
+        features: [
+            FeatureType.DASHBOARD_COG_MENU,
+            FeatureType.DASHBOARD_CUSTOM_WIDGET
+        ],
         debug: true
     }
 };
@@ -157,6 +160,10 @@ export class MockClient
 
     log(message: string): void {
         return this.logger.log(message);
+    }
+
+    logWarning(message: string): void {
+        return this.logger.warn(message);
     }
 
     logError(message: string): void {


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

Deprecate dashboard_timeframe_change and dashboard_template_var_change events in favor of the more consistent and general `context_change` event.

<!-- - Is this a bugfix or a feature? -->

## Changes

Adds deprecation warnings on subscriptions to these events
Adds reporting of usage of deprecated events to web-ui with a new request type
Updates documentation, removing instructions related to these events

## Testing

Test app to come

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/ui-extensions-react@0.29.1-canary.114.ea28f79.0
  npm install @datadog/ui-extensions-sdk@0.29.1-canary.114.ea28f79.0
  # or 
  yarn add @datadog/ui-extensions-react@0.29.1-canary.114.ea28f79.0
  yarn add @datadog/ui-extensions-sdk@0.29.1-canary.114.ea28f79.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
