### PR TITLE
Start on a go example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,10 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true
     },
+    "go.toolsEnvVars": {
+        "GOARCH": "wasm",
+        "GOOS": "js"
+    },
     "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
     "prettier.configPath": "prettier.config.js",
     "search.exclude": {

--- a/examples/go-dashboard-cog-menu-item/Makefile
+++ b/examples/go-dashboard-cog-menu-item/Makefile
@@ -1,0 +1,27 @@
+.SUFFIXES:
+Makefile:;
+
+.DEFAULT_GOAL := dist/index.html
+
+.PHONY: clean
+clean:
+	rm -fr dist
+
+dist:
+	mkdir -p $@
+
+dist/index.html: index.html dist/index.js
+	cp $< $@
+
+dist/index.js: dist/main.wasm dist/wasm_exec.js
+	touch $@
+
+dist/main.wasm: app/main.go | dist
+	GOOS=js GOARCH=wasm go build -o $@ $<
+
+dist/wasm_exec.js: | dist
+	cp "$$(go env GOROOT)/misc/wasm/wasm_exec.js" $@
+
+.PHONY: serve
+serve: dist/index.html
+	go run server/main.go

--- a/examples/go-dashboard-cog-menu-item/app/main.go
+++ b/examples/go-dashboard-cog-menu-item/app/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+
+	uiextensionsgo "github.com/DataDog/apps/packages/ui-extensions-go"
+)
+
+const templateVariableName = "variable-1"
+
+func handler(client *uiextensionsgo.Client) func(uiextensionsgo.DashboardCogMenuClickData) {
+	return func(data uiextensionsgo.DashboardCogMenuClickData) {
+		var templateVariable string
+		var found bool
+		for _, variable := range data.Dashboard.TemplateVars {
+			if variable.Name == templateVariableName {
+				found = true
+				templateVariable = variable.Value
+				break
+			}
+		}
+
+		if !found {
+			/**
+			 * We couldn't find the template variable we were looking for,
+			 * so we bail.
+			 */
+			return
+		}
+
+		/**
+		 * We're showing that we can actually call back out to JS with data from go.
+		 *
+		 * In this case, we send a notification of whatever the template variable value is.
+		 */
+		message := fmt.Sprintf("Received the template variable: %s\n", templateVariable)
+		notification := uiextensionsgo.NotificationDefinition{
+			Label: message,
+			Level: "success",
+		}
+		client.Notify(notification)
+	}
+}
+
+func main() {
+	/**
+	 * This should be enough to initialize the client and respond to the handshake,
+	 * but it doesn't seem to be enough.
+	 * We still need to have a call to `DD_SDK.init()` in JS.
+	 */
+	client := uiextensionsgo.Init()
+	client.OnDashboardCogMenuClick(handler(client))
+
+	/**
+	 * Block so the program doesn't end.
+	 */
+	<-make(chan struct{})
+}

--- a/examples/go-dashboard-cog-menu-item/index.html
+++ b/examples/go-dashboard-cog-menu-item/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Datadog App - go - dashboard cog menu item</title>
+</head>
+<body>
+    <script src="wasm_exec.js"></script>
+    <script src="https://unpkg.com/@datadog/ui-extensions-sdk@0.29.0/dist/ui-extensions-sdk.min.js"></script>
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then(result => {
+            go.run(result.instance)
+        });
+
+        // It's unclear why we need this, but we do.
+        // If we remove it, the handshake fails.
+        const client = DD_SDK.init();
+    </script>
+</body>
+</html>

--- a/examples/go-dashboard-cog-menu-item/server/main.go
+++ b/examples/go-dashboard-cog-menu-item/server/main.go
@@ -1,0 +1,17 @@
+// This package has to be separate from the App because WASM and native builds don't play well together.
+
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func main() {
+	distDir := http.Dir("dist")
+	fileServer := http.FileServer(distDir)
+	err := http.ListenAndServe(":8080", fileServer)
+	if err != nil {
+		log.Fatalf("Failed to start server: %+v\n", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/DataDog/apps
+
+go 1.16

--- a/packages/ui-extensions-go/README.md
+++ b/packages/ui-extensions-go/README.md
@@ -1,0 +1,3 @@
+# UI Extensions SDK in go
+
+This is an experimental interface to Datadog UI Extensions from go.

--- a/packages/ui-extensions-go/sdk.go
+++ b/packages/ui-extensions-go/sdk.go
@@ -1,0 +1,80 @@
+package uiextensionsgo
+
+import (
+	"encoding/json"
+	"fmt"
+	"syscall/js"
+)
+
+type Client struct {
+	js.Value
+}
+
+func Init() *Client {
+	sdk := js.Global().Get("DD_SDK")
+	client := sdk.Call("init")
+	return &Client{
+		client,
+	}
+}
+
+type DashboardCogMenuClickData struct {
+	Dashboard DashboardContext `json:"dashboard"`
+	MenuItem  MenuItemContext  `json:"menuItem"`
+}
+
+type DashboardContext struct {
+	Id           string                  `json:"id"`
+	ShareURL     string                  `json:"shareURL"`
+	TemplateVars []TemplateVariableValue `json:"templateVars"`
+}
+
+type MenuItemContext struct {
+	Key string `json:"key"`
+}
+
+type NotificationDefinition struct {
+	Label string `json:"label"`
+	Level string `json:"level"`
+}
+
+type TemplateVariableValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func (client *Client) Notify(definition NotificationDefinition) {
+	jsonBytes, err := json.Marshal(definition)
+	if err != nil {
+		fmt.Printf("Unabled to serialize as JSON, error: %+v\n", err)
+		return
+	}
+
+	jsonString := js.ValueOf(string(jsonBytes))
+	notification := js.Global().Get("JSON").Call("parse", jsonString)
+	client.Get("notification").Call("send", (notification))
+}
+
+func (client *Client) OnDashboardCogMenuClick(handler func(DashboardCogMenuClickData)) {
+	client.Call("on", "dashboard_cog_menu_click", js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		if len(args) < 1 {
+			fmt.Printf("Expected at least one argument, received: %+v\n", args)
+			return nil
+		}
+
+		eventData := args[0]
+		dashboardCogMenuClickData := &DashboardCogMenuClickData{}
+		jsonString := js.Global().Get("JSON").Call("stringify", eventData).String()
+		raw := []byte(jsonString)
+
+		err := json.Unmarshal(raw, dashboardCogMenuClickData)
+		if err != nil {
+			fmt.Printf("Incorrect data received from SDK, received: %s\nerror: %+v\n", raw, err)
+			return nil
+		}
+
+		handler(*dashboardCogMenuClickData)
+
+		return nil
+	}))
+}


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- We want to show that it's possible to build an App without writing a ton of JavaScript.

<!-- - Is this a bugfix or a feature? -->

## Changes

- We create a very simple App in go that only uses the `"dashboard_cog_menu"` feature. This App has a single item that when clicked will search for a specific template variable, then send a notification back to Datadog with the value of that template variable. This shows that it's entirely possible to communicate back and forth between golang and JavaScript.
- The magic that makes this happen is that go can compile to WASM easily. We take the WASM, run it in the browser, and the rest is history.
- This is not really usable as it is. If we want to get serious about this, we should extract a go package that actually makes it easier to use this stuff. Likely we'd be able to get away with just doing a little JSON serialization/deserialization to plain go types. This mainly exists as a proof-of-concept.

<!-- - If there's a UI Change: please include a screenshot. -->
<!-- - If there's not a UI Change: please remove this table. -->

![example of the App running](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/6quZ0LE8/c2ce8f37-45a1-4bc4-9f30-dc6db95d7241.gif?v=1e2fb8fb47fc343c54a3c38b153cdac8)

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

- TODO

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [x] All packages that need a release have a changeset.