### PR TITLE
UIAPPS-147 Add hooks for custom widget options

### DIFF
--- a/.changeset/lazy-tigers-act.md
+++ b/.changeset/lazy-tigers-act.md
@@ -1,0 +1,5 @@
+---
+'@datadog/ui-extensions-sdk': patch
+---
+
+Bump for release of `@datadog/ui-extensions-react` package.

--- a/.changeset/small-pens-end.md
+++ b/.changeset/small-pens-end.md
@@ -1,0 +1,16 @@
+---
+'@datadog/create-app': minor
+'@datadog/ui-extensions-react': patch
+---
+
+Add a few react hooks (`useCustomWidgetOption`, `useCustomWidgetOptionBoolean`, `useCustomWidgetOptionString`) for working custom widget options.
+
+Dealing with custom widget options can be a bit difficult to get right.
+You have to at least:
+grab the initial options from the context,
+listen for changes on the event,
+unsubscribe from event changes when unmounted,
+and check that the value actually exists.
+
+These new hooks hopefully make that easier.
+They manage all the intricacies of dealing with custom widget options so the App can focus on the logic that's important.

--- a/.changeset/small-pens-end.md
+++ b/.changeset/small-pens-end.md
@@ -3,7 +3,7 @@
 '@datadog/ui-extensions-react': patch
 ---
 
-Add a few react hooks (`useCustomWidgetOption`, `useCustomWidgetOptionBoolean`, `useCustomWidgetOptionString`) for working custom widget options.
+Add a few react hooks (`useCustomWidgetOption`, `useCustomWidgetOptionBoolean`, `useCustomWidgetOptionString`) for working with custom widget options.
 
 Dealing with custom widget options can be a bit difficult to get right.
 You have to at least:

--- a/examples/geomap/datadog-app/src/widget/HelloWorld/index.tsx
+++ b/examples/geomap/datadog-app/src/widget/HelloWorld/index.tsx
@@ -1,4 +1,5 @@
-import { init, EventType } from '@datadog/ui-extensions-sdk';
+import { useCustomWidgetOptionString } from '@datadog/ui-extensions-react';
+import { init } from '@datadog/ui-extensions-sdk';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -12,24 +13,10 @@ import { useEffect, useState } from 'react';
 const client = init();
 
 function Widget() {
-    const [metric, setMetric] = useState('system.cpu.idle');
+    const metric = useCustomWidgetOptionString(client, 'metric');
     const [broadcastClickCount, setBroadcastClickCount] = useState(0);
 
     useEffect(() => {
-        client.getContext().then(c => {
-            setMetric(c.widget?.definition.options?.metric);
-        });
-
-        client.events.on(
-            EventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
-            ({ metric }) => {
-                if (typeof metric !== 'string') {
-                    return;
-                }
-                setMetric(metric);
-            }
-        );
-
         client.events.onCustom('modal_button_click', setBroadcastClickCount);
     }, []);
 

--- a/examples/random-dog/dog-image-widget/src/widget/index.tsx
+++ b/examples/random-dog/dog-image-widget/src/widget/index.tsx
@@ -1,9 +1,5 @@
-import { useContext } from '@datadog/ui-extensions-react';
-import {
-    WidgetOptionItemType,
-    init,
-    EventType
-} from '@datadog/ui-extensions-sdk';
+import { useCustomWidgetOptionString } from '@datadog/ui-extensions-react';
+import { init, WidgetOptionItemType } from '@datadog/ui-extensions-sdk';
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -17,7 +13,7 @@ const client = init();
 function Widget() {
     const [breeds, setBreeds] = useState([]);
     const [image, setImage] = useState(null);
-    const context = useContext(client);
+    const breed = useCustomWidgetOptionString(client, 'breed');
 
     useEffect(() => {
         fetch('http://localhost:3001/breeds')
@@ -55,22 +51,18 @@ function Widget() {
     }, [breeds]);
 
     useEffect(() => {
-        client.events.on(
-            EventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
-            ({ breed }) => {
-                if (breed !== undefined) {
-                    getImage(breed.toString());
-                }
-            }
-        );
-    }, []);
-
-    const cycleImage = async () => {
-        if (context === undefined) {
+        if (breed === undefined) {
             return;
         }
 
-        const breed = context.widget?.definition.options?.breed;
+        getImage(breed);
+    }, [breed]);
+
+    const cycleImage = async () => {
+        if (breed === undefined) {
+            return;
+        }
+
         getImage(breed);
     };
 

--- a/examples/starter-kit/src/widget/index.tsx
+++ b/examples/starter-kit/src/widget/index.tsx
@@ -1,5 +1,5 @@
-import { useContext } from '@datadog/ui-extensions-react';
-import { init, EventType } from '@datadog/ui-extensions-sdk';
+import { useCustomWidgetOptionString } from '@datadog/ui-extensions-react';
+import { init } from '@datadog/ui-extensions-sdk';
 import './../index.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -12,27 +12,12 @@ import { useEffect, useState } from 'react';
 const client = init();
 
 function Widget() {
-    const context = useContext(client);
-    const [metric, setMetric] = useState('system.cpu.idle');
+    const metric = useCustomWidgetOptionString(client, 'metric');
     const [broadcastClickCount, setBroadcastClickCount] = useState(0);
 
     useEffect(() => {
-        if (context !== undefined) {
-            setMetric(context.widget?.definition.options?.metric);
-        }
-
-        client.events.on(
-            EventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
-            ({ metric }) => {
-                if (typeof metric !== 'string') {
-                    return;
-                }
-                setMetric(metric);
-            }
-        );
-
         client.events.onCustom('modal_button_click', setBroadcastClickCount);
-    }, [context]);
+    }, []);
 
     const onOpenSidePanel = (args: any) => {
         client.sidePanel.open(

--- a/packages/create-app/src/template/package.json
+++ b/packages/create-app/src/template/package.json
@@ -3,8 +3,8 @@
     "version": "0.0.0",
     "private": true,
     "dependencies": {
-        "@datadog/ui-extensions-react": "0.26.0",
-        "@datadog/ui-extensions-sdk": "0.26.0",
+        "@datadog/ui-extensions-react": "0.30.1",
+        "@datadog/ui-extensions-sdk": "0.30.1",
         "@types/node": "^14.14.14",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",

--- a/packages/create-app/src/template/src/custom-widget/index.tsx
+++ b/packages/create-app/src/template/src/custom-widget/index.tsx
@@ -1,5 +1,5 @@
-import { useContext } from '@datadog/ui-extensions-react';
-import { init, EventType } from '@datadog/ui-extensions-sdk';
+import { useCustomWidgetOptionString } from '@datadog/ui-extensions-react';
+import { init } from '@datadog/ui-extensions-sdk';
 import './../index.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -12,27 +12,12 @@ import { useEffect, useState } from 'react';
 const client = init();
 
 function CustomWidget() {
-    const context = useContext(client);
-    const [metric, setMetric] = useState('system.cpu.idle');
+    const metric = useCustomWidgetOptionString(client, 'metric');
     const [broadcastClickCount, setBroadcastClickCount] = useState(0);
 
     useEffect(() => {
-        if (context !== undefined) {
-            setMetric(context.widget?.definition.options?.metric);
-        }
-
-        client.events.on(
-            EventType.DASHBOARD_CUSTOM_WIDGET_OPTIONS_CHANGE,
-            ({ metric }) => {
-                if (typeof metric !== 'string') {
-                    return;
-                }
-                setMetric(metric);
-            }
-        );
-
         client.events.onCustom('modal_button_click', setBroadcastClickCount);
-    }, [context]);
+    }, []);
 
     const onOpenSidePanel = (args: any) => {
         client.sidePanel.open(

--- a/packages/ui-extensions-react/src/index.ts
+++ b/packages/ui-extensions-react/src/index.ts
@@ -1,2 +1,5 @@
 export * from './use-context';
+export * from './use-custom-widget-option';
+export * from './use-custom-widget-option-boolean';
+export * from './use-custom-widget-option-string';
 export * from './use-template-variable';

--- a/packages/ui-extensions-react/src/use-custom-widget-option-boolean.test.ts
+++ b/packages/ui-extensions-react/src/use-custom-widget-option-boolean.test.ts
@@ -1,0 +1,140 @@
+import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+import * as reactHooks from '@testing-library/react-hooks';
+
+import { useCustomWidgetOptionBoolean } from './use-custom-widget-option-boolean';
+
+/**
+ * Lifted from `@datadog/ui-extensions-sdk/src/utils/testUtils`.
+ */
+interface Deferred<Value> {
+    promise: Promise<Value>;
+    reject: (t: unknown) => void;
+    resolve: (t: Value) => void;
+}
+
+/**
+ * Lifted from `@datadog/ui-extensions-sdk/src/utils/testUtils`.
+ */
+const defer = <Value>(): Deferred<Value> => {
+    let reject: (error: unknown) => void = () => {};
+    let resolve: (value: Value) => void = () => {};
+    const promise = new Promise<Value>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return {
+        promise,
+        reject,
+        resolve
+    };
+};
+
+let deferredContext: Deferred<uiExtensionsSDK.Context>;
+
+jest.mock('@datadog/ui-extensions-sdk', () => {
+    return {
+        ...jest.requireActual<object>('@datadog/ui-extensions-sdk'),
+        DDClient: jest.fn(() => {
+            return {
+                events: {
+                    on: jest.fn((): (() => void) => {
+                        return jest.fn();
+                    })
+                },
+                getContext: jest.fn(
+                    (): Promise<uiExtensionsSDK.Context> => {
+                        return deferredContext.promise;
+                    }
+                )
+            };
+        })
+    };
+});
+
+beforeEach((): void => {
+    deferredContext = defer();
+    jest.clearAllMocks();
+});
+
+describe('useCustomWidgetOptionBoolean', (): void => {
+    test('returns `undefined` if option is not set', (): void => {
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useCustomWidgetOptionBoolean(client, 'option1');
+        });
+
+        expect(result.result.current).toBe(undefined);
+    });
+
+    test('returns `undefined` if option is not a boolean', async (): Promise<
+        void
+    > => {
+        const context: uiExtensionsSDK.Context = {
+            app: {
+                currentUser: {
+                    colorTheme: uiExtensionsSDK.ColorTheme.light,
+                    timeZone: ''
+                },
+                debug: false,
+                features: []
+            },
+            widget: {
+                definition: {
+                    custom_widget_key: 'key',
+                    options: {
+                        option1: 'some string'
+                    }
+                }
+            }
+        };
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useCustomWidgetOptionBoolean(client, 'option1');
+        });
+        await reactHooks.act(
+            async (): Promise<void> => {
+                deferredContext.resolve(context);
+                await result.waitForNextUpdate();
+            }
+        );
+
+        expect(result.result.current).toBe(undefined);
+    });
+
+    test('updates with data from the context', async (): Promise<void> => {
+        const context: uiExtensionsSDK.Context = {
+            app: {
+                currentUser: {
+                    colorTheme: uiExtensionsSDK.ColorTheme.light,
+                    timeZone: ''
+                },
+                debug: false,
+                features: []
+            },
+            widget: {
+                definition: {
+                    custom_widget_key: 'key',
+                    options: {
+                        option1: true
+                    }
+                }
+            }
+        };
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useCustomWidgetOptionBoolean(client, 'option1');
+        });
+        await reactHooks.act(
+            async (): Promise<void> => {
+                deferredContext.resolve(context);
+                await result.waitForNextUpdate();
+            }
+        );
+
+        expect(result.result.current).toEqual(true);
+    });
+});

--- a/packages/ui-extensions-react/src/use-custom-widget-option-boolean.ts
+++ b/packages/ui-extensions-react/src/use-custom-widget-option-boolean.ts
@@ -1,0 +1,54 @@
+import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+
+import { useCustomWidgetOption } from './use-custom-widget-option';
+
+/**
+ * Returns the current value of a single custom widget option that is expected to be a {@link boolean}.
+ * This will be updated whenever the options change.
+ *
+ * This hook abstracts away the intricacies of keeping up to date with an option.
+ *
+ * @param client An initialized {@link uiExtensionsSDK.DDClient}. This should be the result of invoking {@link uiExtensionsSDK.init}.
+ * @param optionName The option name to look for.
+ * @returns The option value (if it exists).
+ *
+ * @example
+ * This hook can be used like:
+ * ```TypeScript
+ * import * as uiExtensionsReact from '@datadog/ui-extensions-react';
+ * import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+ * import * as React from 'react';
+ *
+ * const client = uiExtensionsSDK.init();
+ *
+ * const CustomWidget: React.FunctionComponent = () => {
+ *     const verbose = uiExtensionsReact.useCustomWidgetOptionBoolean(client, 'verbose');
+ *
+ *     if (query == null) {
+ *         return <p>Please decide on verbosity</p>;
+ *     } else {
+ *         return <p>Verbose: {verbose}</p>;
+ *     }
+ * }
+ * ```
+ */
+function useCustomWidgetOptionBoolean(
+    client: uiExtensionsSDK.DDClient,
+    optionName: string
+): boolean | undefined {
+    const option: boolean | undefined = useCustomWidgetOption(
+        client,
+        optionName,
+        (newOption: string | boolean): boolean | undefined => {
+            if (typeof newOption !== 'boolean') {
+                return;
+            }
+
+            return newOption;
+        }
+    );
+
+    return option;
+}
+
+export { useCustomWidgetOptionBoolean };

--- a/packages/ui-extensions-react/src/use-custom-widget-option-boolean.ts
+++ b/packages/ui-extensions-react/src/use-custom-widget-option-boolean.ts
@@ -24,7 +24,7 @@ import { useCustomWidgetOption } from './use-custom-widget-option';
  * const CustomWidget: React.FunctionComponent = () => {
  *     const verbose = uiExtensionsReact.useCustomWidgetOptionBoolean(client, 'verbose');
  *
- *     if (query == null) {
+ *     if (verbose == null) {
  *         return <p>Please decide on verbosity</p>;
  *     } else {
  *         return <p>Verbose: {verbose}</p>;

--- a/packages/ui-extensions-react/src/use-custom-widget-option-string.test.ts
+++ b/packages/ui-extensions-react/src/use-custom-widget-option-string.test.ts
@@ -1,0 +1,140 @@
+import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+import * as reactHooks from '@testing-library/react-hooks';
+
+import { useCustomWidgetOptionString } from './use-custom-widget-option-string';
+
+/**
+ * Lifted from `@datadog/ui-extensions-sdk/src/utils/testUtils`.
+ */
+interface Deferred<Value> {
+    promise: Promise<Value>;
+    reject: (t: unknown) => void;
+    resolve: (t: Value) => void;
+}
+
+/**
+ * Lifted from `@datadog/ui-extensions-sdk/src/utils/testUtils`.
+ */
+const defer = <Value>(): Deferred<Value> => {
+    let reject: (error: unknown) => void = () => {};
+    let resolve: (value: Value) => void = () => {};
+    const promise = new Promise<Value>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return {
+        promise,
+        reject,
+        resolve
+    };
+};
+
+let deferredContext: Deferred<uiExtensionsSDK.Context>;
+
+jest.mock('@datadog/ui-extensions-sdk', () => {
+    return {
+        ...jest.requireActual<object>('@datadog/ui-extensions-sdk'),
+        DDClient: jest.fn(() => {
+            return {
+                events: {
+                    on: jest.fn((): (() => void) => {
+                        return jest.fn();
+                    })
+                },
+                getContext: jest.fn(
+                    (): Promise<uiExtensionsSDK.Context> => {
+                        return deferredContext.promise;
+                    }
+                )
+            };
+        })
+    };
+});
+
+beforeEach((): void => {
+    deferredContext = defer();
+    jest.clearAllMocks();
+});
+
+describe('useCustomWidgetOptionString', (): void => {
+    test('returns `undefined` if option is not set', (): void => {
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useCustomWidgetOptionString(client, 'option1');
+        });
+
+        expect(result.result.current).toBe(undefined);
+    });
+
+    test('returns `undefined` if option is not a string', async (): Promise<
+        void
+    > => {
+        const context: uiExtensionsSDK.Context = {
+            app: {
+                currentUser: {
+                    colorTheme: uiExtensionsSDK.ColorTheme.light,
+                    timeZone: ''
+                },
+                debug: false,
+                features: []
+            },
+            widget: {
+                definition: {
+                    custom_widget_key: 'key',
+                    options: {
+                        option1: true
+                    }
+                }
+            }
+        };
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useCustomWidgetOptionString(client, 'option1');
+        });
+        await reactHooks.act(
+            async (): Promise<void> => {
+                deferredContext.resolve(context);
+                await result.waitForNextUpdate();
+            }
+        );
+
+        expect(result.result.current).toBe(undefined);
+    });
+
+    test('updates with data from the context', async (): Promise<void> => {
+        const context: uiExtensionsSDK.Context = {
+            app: {
+                currentUser: {
+                    colorTheme: uiExtensionsSDK.ColorTheme.light,
+                    timeZone: ''
+                },
+                debug: false,
+                features: []
+            },
+            widget: {
+                definition: {
+                    custom_widget_key: 'key',
+                    options: {
+                        option1: 'hello'
+                    }
+                }
+            }
+        };
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useCustomWidgetOptionString(client, 'option1');
+        });
+        await reactHooks.act(
+            async (): Promise<void> => {
+                deferredContext.resolve(context);
+                await result.waitForNextUpdate();
+            }
+        );
+
+        expect(result.result.current).toEqual('hello');
+    });
+});

--- a/packages/ui-extensions-react/src/use-custom-widget-option-string.ts
+++ b/packages/ui-extensions-react/src/use-custom-widget-option-string.ts
@@ -1,0 +1,54 @@
+import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+
+import { useCustomWidgetOption } from './use-custom-widget-option';
+
+/**
+ * Returns the current value of a single custom widget option that is expected to be a {@link string}.
+ * This will be updated whenever the options change.
+ *
+ * This hook abstracts away the intricacies of keeping up to date with an option.
+ *
+ * @param client An initialized {@link uiExtensionsSDK.DDClient}. This should be the result of invoking {@link uiExtensionsSDK.init}.
+ * @param optionName The option name to look for.
+ * @returns The option value (if it exists).
+ *
+ * @example
+ * This hook can be used like:
+ * ```TypeScript
+ * import * as uiExtensionsReact from '@datadog/ui-extensions-react';
+ * import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+ * import * as React from 'react';
+ *
+ * const client = uiExtensionsSDK.init();
+ *
+ * const CustomWidget: React.FunctionComponent = () => {
+ *     const query = uiExtensionsReact.useCustomWidgetOptionString(client, 'query');
+ *
+ *     if (query == null) {
+ *         return <p>Please set a query</p>;
+ *     } else {
+ *         return <p>Query: {query}</p>;
+ *     }
+ * }
+ * ```
+ */
+function useCustomWidgetOptionString(
+    client: uiExtensionsSDK.DDClient,
+    optionName: string
+): string | undefined {
+    const option: string | undefined = useCustomWidgetOption(
+        client,
+        optionName,
+        (newOption: string | boolean): string | undefined => {
+            if (typeof newOption !== 'string') {
+                return;
+            }
+
+            return newOption;
+        }
+    );
+
+    return option;
+}
+
+export { useCustomWidgetOptionString };

--- a/packages/ui-extensions-react/src/use-custom-widget-option.test.ts
+++ b/packages/ui-extensions-react/src/use-custom-widget-option.test.ts
@@ -1,0 +1,105 @@
+import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+import * as reactHooks from '@testing-library/react-hooks';
+
+import { useCustomWidgetOption } from './use-custom-widget-option';
+
+/**
+ * Lifted from `@datadog/ui-extensions-sdk/src/utils/testUtils`.
+ */
+interface Deferred<Value> {
+    promise: Promise<Value>;
+    reject: (t: unknown) => void;
+    resolve: (t: Value) => void;
+}
+
+/**
+ * Lifted from `@datadog/ui-extensions-sdk/src/utils/testUtils`.
+ */
+const defer = <Value>(): Deferred<Value> => {
+    let reject: (error: unknown) => void = () => {};
+    let resolve: (value: Value) => void = () => {};
+    const promise = new Promise<Value>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return {
+        promise,
+        reject,
+        resolve
+    };
+};
+
+let deferredContext: Deferred<uiExtensionsSDK.Context>;
+
+jest.mock('@datadog/ui-extensions-sdk', () => {
+    return {
+        ...jest.requireActual<object>('@datadog/ui-extensions-sdk'),
+        DDClient: jest.fn(() => {
+            return {
+                events: {
+                    on: jest.fn((): (() => void) => {
+                        return jest.fn();
+                    })
+                },
+                getContext: jest.fn(
+                    (): Promise<uiExtensionsSDK.Context> => {
+                        return deferredContext.promise;
+                    }
+                )
+            };
+        })
+    };
+});
+
+beforeEach((): void => {
+    deferredContext = defer();
+    jest.clearAllMocks();
+});
+
+describe('useCustomWidgetOption', (): void => {
+    test('defaults to `undefined` if option is not set', (): void => {
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useCustomWidgetOption(client, 'option1', option => option);
+        });
+
+        expect(result.result.current).toBe(undefined);
+    });
+
+    test('updates with data from the context', async (): Promise<void> => {
+        const context: uiExtensionsSDK.Context = {
+            app: {
+                currentUser: {
+                    colorTheme: uiExtensionsSDK.ColorTheme.light,
+                    timeZone: ''
+                },
+                debug: false,
+                features: []
+            },
+            widget: {
+                definition: {
+                    custom_widget_key: 'key',
+                    options: {
+                        option1: true,
+                        option2: 'hello'
+                    }
+                }
+            }
+        };
+        const client = new uiExtensionsSDK.DDClient();
+
+        const result = reactHooks.renderHook(() => {
+            return useCustomWidgetOption(client, 'option1', option => option);
+        });
+        await reactHooks.act(
+            async (): Promise<void> => {
+                deferredContext.resolve(context);
+                await result.waitForNextUpdate();
+            }
+        );
+
+        expect(result.result.current).toEqual(true);
+    });
+});

--- a/packages/ui-extensions-react/src/use-custom-widget-option.ts
+++ b/packages/ui-extensions-react/src/use-custom-widget-option.ts
@@ -1,0 +1,77 @@
+import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+import * as React from 'react';
+
+import * as useContext from './use-context';
+
+/**
+ * Returns the current value of a single custom widget option.
+ * This will be updated whenever the options change.
+ *
+ * This hook abstracts away the intricacies of keeping options up to date.
+ *
+ * @param client An initialized {@link uiExtensionsSDK.DDClient}. This should be the result of invoking {@link uiExtensionsSDK.init}.
+ * @param optionName The option name to look for.
+ * @param parser A function for parsing the option value.
+ * @returns The option value (if it exists).
+ *
+ * @example
+ * This hook can be used like:
+ * ```TypeScript
+ * import * as uiExtensionsReact from '@datadog/ui-extensions-react';
+ * import * as uiExtensionsSDK from '@datadog/ui-extensions-sdk';
+ * import * as React from 'react';
+ *
+ * const client = uiExtensionsSDK.init();
+ *
+ * const parseInt = (option: string | boolean): number | undefined => {
+ *     if (typeof option !== 'string') {
+ *         return;
+ *     }
+ *
+ *     const parsed: number = Number.parseInt(option);
+ *     if (Number.isNaN(parsed)) {
+ *         return;
+ *     }
+ *
+ *     return parsed;
+ * };
+ *
+ * const CustomWidget: React.FunctionComponent = () => {
+ *     const threshold = uiExtensionsReact.useCustomWidgetOption(client, 'threshold', parseInt);
+ *
+ *     if (threshold == null) {
+ *         return <p>Please set a threshold</p>;
+ *     } else {
+ *         return <p>Threshold: {threshold}</p>;
+ *     }
+ * }
+ * ```
+ */
+function useCustomWidgetOption<Result>(
+    client: uiExtensionsSDK.DDClient,
+    optionName: string,
+    parser: (option: string | boolean) => Result | undefined
+): Result | undefined {
+    const context = useContext.useContext(client);
+    const [option, setOption] = React.useState<Result>();
+
+    React.useEffect(() => {
+        if (context == null) {
+            return;
+        }
+
+        const initialOption: string | boolean | undefined =
+            context.widget?.definition.options?.[optionName];
+        if (initialOption == null) {
+            setOption(undefined);
+            return;
+        }
+
+        const parsed = parser(initialOption);
+        setOption(parsed);
+    }, [context, context?.widget?.definition.options, optionName, parser]);
+
+    return option;
+}
+
+export { useCustomWidgetOption };


### PR DESCRIPTION
Motivation
----------

- Jira Issue: https://datadoghq.atlassian.net/browse/UIAPPS-147
- Previous PR: https://github.com/DataDog/apps/pull/108
- Much like the `useTemplateVariable` hook did for working with template variables, we want to abstract away some of the intricacies of dealing with custom widget options. It can be hard to get right, so we want a hook that makes it easier to do the right thing.

Changes
-------

- We add three new hooks that make it easier to work with custom widget options.
    - The `useCustomWidgetOption` hook is the main implementation. It supports a parser that is used by the others while also making it possible to refine values a bit better.
    - The `useCustomWidgetOptionBoolean` and `useCustomWidgetOptionString` hooks provide easier to use helpers for the common case of dealing with a boolean or string options, respectively.
- These hooks implement the updated API as described in https://github.com/DataDog/apps/pull/108#issuecomment-1042038199.
- We also update the example Apps to use these new hooks.

Testing
-------

- We added a suite of tests for these hooks, so we should catch the majority of issues.

Releases
--------

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [x] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/create-app@1.1.1-canary.121.b4c4373.0
  npm install @datadog/ui-extensions-react@0.30.1-canary.121.b4c4373.0
  # or 
  yarn add @datadog/create-app@1.1.1-canary.121.b4c4373.0
  yarn add @datadog/ui-extensions-react@0.30.1-canary.121.b4c4373.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
