### PR TITLE
Security network resource monitoring

### DIFF
--- a/.changeset/modern-pens-travel.md
+++ b/.changeset/modern-pens-travel.md
@@ -1,0 +1,6 @@
+---
+'@datadog/ui-extensions-sdk': patch
+'@datadog/ui-extensions-react': patch
+---
+
+Add security monitoring hooks

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -31,3 +31,7 @@ You can authenticate your app users by integrating your existing login mechanism
 ## What browsers do you support?
 
 Our intention is to support all major browsers, however we have encountered some errors in both Safari and Firefox. We are actively investigating these issues, but in the meantime we recommend using Google Chrome when developing and using apps with UI Extensions.
+
+## What information does Datadog collect about my code?
+
+To ensure safety and reliability for our customers, Datadog collects information on all loaded resources and network calls executed in your app IFrames. The specific collection routines are open-source and can be viewed [here](https://github.com/DataDog/apps/tree/master/packages/ui-extensions-sdk/src/utils/security.ts). Please reach out to <apps@datadoghq.com> if you have further questions.

--- a/packages/ui-extensions-sdk/src/client/client.ts
+++ b/packages/ui-extensions-sdk/src/client/client.ts
@@ -220,9 +220,6 @@ export class DDClient<AuthStateArgs = unknown>
         let loadedResourceIds: LoadedResourceIds = new Set();
 
         if (!this.supportPerformanceObject()) {
-            this.logger.warn(
-                'resource monitoring is disabled because browser does not support performance object'
-            );
             return;
         }
 

--- a/packages/ui-extensions-sdk/src/client/client.ts
+++ b/packages/ui-extensions-sdk/src/client/client.ts
@@ -24,16 +24,12 @@ import type {
     EventHandler,
     IFrameDimensions,
     LoggerClient,
-    NetworkRequestMetadata,
     ParentAuthStateOptions,
     RequestClient,
     RequestHandler
 } from '../types';
 import { Logger } from '../utils/logger';
-import {
-    collectResourceUsage,
-    registerNetworkRequestListeners
-} from '../utils/security';
+import { collectResourceUsage } from '../utils/security';
 import type { LoadedResourceIds } from '../utils/security';
 import { setImmediateInterval } from '../utils/utils';
 import { DDWidgetContextMenuClient } from '../widget-context-menu/widget-context-menu';
@@ -114,7 +110,6 @@ export class DDClient<AuthStateArgs = unknown>
         });
 
         this.registerEventListeners();
-        this.startNetworkMonitoring();
         this.startResourceMonitoring();
     }
 
@@ -256,21 +251,5 @@ export class DDClient<AuthStateArgs = unknown>
                 }
             );
         }
-    }
-
-    private startNetworkMonitoring() {
-        const removeListeners = registerNetworkRequestListeners(
-            (networkRequest: NetworkRequestMetadata) => {
-                this.framePostClient
-                    .request(
-                        RequestType.SECURITY_LOG_NETWORK_REQUEST,
-                        networkRequest
-                    )
-                    .catch(e => {
-                        // Remove listeners on error
-                        removeListeners();
-                    });
-            }
-        );
     }
 }

--- a/packages/ui-extensions-sdk/src/client/client.ts
+++ b/packages/ui-extensions-sdk/src/client/client.ts
@@ -104,9 +104,9 @@ export class DDClient<AuthStateArgs = unknown>
 
         this.registerEventListeners();
 
-        startResourceMonitoring(async batch => {
-            await this.framePostClient.request(
-                RequestType.SECURITY_LOG_RESOURCES_LOADED,
+        startResourceMonitoring(batch => {
+            this.framePostClient.send(
+                EventType.SECURITY_LOG_RESOURCES_LOADED,
                 batch
             );
         });

--- a/packages/ui-extensions-sdk/src/client/client.ts
+++ b/packages/ui-extensions-sdk/src/client/client.ts
@@ -233,6 +233,14 @@ export class DDClient<AuthStateArgs = unknown>
                 clearInterval(interval);
             }
         }, RESOURCE_BATCH_INTERVAL);
+
+        addEventListener('resourcetimingbufferfull', event => {
+            // TODO: maybe reset the buffer using performance.clearResourceTimings() instead ?
+            clearInterval(interval);
+            this.logger.warn(
+                'Resource timing buffer is full, stopping resource monitoring'
+            );
+        });
     }
 
     private startNetworkMonitoring() {

--- a/packages/ui-extensions-sdk/src/constants.ts
+++ b/packages/ui-extensions-sdk/src/constants.ts
@@ -33,7 +33,8 @@ export enum EventType {
 
     // Auth
     AUTH_STATE_CHANGE = 'auth_state_change',
-    API_ACCESS_CHANGE = 'api_access_change'
+    API_ACCESS_CHANGE = 'api_access_change',
+    SECURITY_LOG_RESOURCES_LOADED = 'security_log_resources'
 }
 
 export const FramePostClientSettings = Object.freeze({
@@ -86,8 +87,7 @@ export enum RequestType {
     // Notifications
     SEND_NOTIFICATION = 'send_notification',
 
-    LOG_DEPRECATED_USAGE = 'log_deprecated_usage',
-    SECURITY_LOG_RESOURCES_LOADED = 'security_log_resources'
+    LOG_DEPRECATED_USAGE = 'log_deprecated_usage'
 }
 
 // These event types are always allowed, regardless of what features have been enabled
@@ -95,7 +95,8 @@ export const enabledEvents = new Set<EventType>([
     EventType.CUSTOM_EVENT,
     EventType.CONTEXT_CHANGE,
     EventType.AUTH_STATE_CHANGE,
-    EventType.API_ACCESS_CHANGE
+    EventType.API_ACCESS_CHANGE,
+    EventType.SECURITY_LOG_RESOURCES_LOADED
 ]);
 
 export enum ModalSize {

--- a/packages/ui-extensions-sdk/src/constants.ts
+++ b/packages/ui-extensions-sdk/src/constants.ts
@@ -86,7 +86,9 @@ export enum RequestType {
     // Notifications
     SEND_NOTIFICATION = 'send_notification',
 
-    LOG_DEPRECATED_USAGE = 'log_deprecated_usage'
+    LOG_DEPRECATED_USAGE = 'log_deprecated_usage',
+    SECURITY_LOG_NETWORK_REQUEST = 'security_log_network_request',
+    SECURITY_LOG_RESOURCES_LOADED = 'security_log_resources'
 }
 
 // These event types are always allowed, regardless of what features have been enabled
@@ -125,3 +127,6 @@ export enum ColorTheme {
     dark = 'dark',
     light = 'light'
 }
+
+// 10 seconds?
+export const RESOURCE_BATCH_INTERVAL = 10000;

--- a/packages/ui-extensions-sdk/src/constants.ts
+++ b/packages/ui-extensions-sdk/src/constants.ts
@@ -87,7 +87,6 @@ export enum RequestType {
     SEND_NOTIFICATION = 'send_notification',
 
     LOG_DEPRECATED_USAGE = 'log_deprecated_usage',
-    SECURITY_LOG_NETWORK_REQUEST = 'security_log_network_request',
     SECURITY_LOG_RESOURCES_LOADED = 'security_log_resources'
 }
 
@@ -128,5 +127,5 @@ export enum ColorTheme {
     light = 'light'
 }
 
-// 10 seconds?
+// 10 seconds
 export const RESOURCE_BATCH_INTERVAL = 10000;

--- a/packages/ui-extensions-sdk/src/constants.ts
+++ b/packages/ui-extensions-sdk/src/constants.ts
@@ -127,6 +127,3 @@ export enum ColorTheme {
     dark = 'dark',
     light = 'light'
 }
-
-// 10 seconds
-export const RESOURCE_BATCH_INTERVAL = 10000;

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -343,7 +343,8 @@ export interface DeprecatedEventUsage {
 export type DeprecatedUsage = DeprecatedEventUsage; // we can union type here later
 
 export interface LoadedResourceMetadata {
-    url: string; // the resources URL
+    url?: string; // the resources URL (set to null in case of network calls for privacy reason)
+    urlHostname: string; // the resource URL hostname
     initiatorType: string; // the type of resource that initiated the performance event (xmlhttprequest, css, img)
     nextHopProtocol: string; // the network protocol used to fetch the resource, as identified by the ALPN Protocol ID (RFC7301).
 }

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -343,11 +343,14 @@ export interface DeprecatedEventUsage {
 export type DeprecatedUsage = DeprecatedEventUsage; // we can union type here later
 
 export interface LoadedResourceMetadata {
-    timestamp: number;
+    startTimeTs: number; // timestamp (in ms) of the resource started being fetched
+    secureConnectionStartTs: number; // timestamp (in ms) of the SSL handshake
     url?: string; // the resources URL (set to null in case of network calls for privacy reason)
     urlHostname: string; // the resource URL hostname
     initiatorType: string; // the type of resource that initiated the performance event (xmlhttprequest, css, img)
     nextHopProtocol: string; // the network protocol used to fetch the resource, as identified by the ALPN Protocol ID (RFC7301).
+    duration: number; // overall time required to fetch the resource
+    decodedBodySize: number; // size of the body after removing any applied content-codings
 }
 
 export interface LoadedResourceMetaDataBatch {

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -345,7 +345,7 @@ export type DeprecatedUsage = DeprecatedEventUsage; // we can union type here la
 export interface LoadedResourceMetadata {
     startTimeTs: number; // timestamp (in ms) of the resource started being fetched
     secureConnectionStartTs: number; // timestamp (in ms) of the SSL handshake
-    url?: string; // the resources URL (set to null in case of network calls for privacy reason)
+    url?: string; // the resources URL (set to null in case of network calls for privacy reason). This value doesn't change even if the request is redirected.
     urlHostname: string; // the resource URL hostname
     initiatorType: string; // the type of resource that initiated the performance event (xmlhttprequest, css, img)
     nextHopProtocol: string; // the network protocol used to fetch the resource, as identified by the ALPN Protocol ID (RFC7301).

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -356,5 +356,3 @@ export interface LoadedResourceMetadata {
 export interface LoadedResourceMetaDataBatch {
     resources: LoadedResourceMetadata[];
 }
-
-export interface NetworkRequestMetadata {}

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -343,6 +343,7 @@ export interface DeprecatedEventUsage {
 export type DeprecatedUsage = DeprecatedEventUsage; // we can union type here later
 
 export interface LoadedResourceMetadata {
+    timestamp: number;
     url?: string; // the resources URL (set to null in case of network calls for privacy reason)
     urlHostname: string; // the resource URL hostname
     initiatorType: string; // the type of resource that initiated the performance event (xmlhttprequest, css, img)

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -342,7 +342,11 @@ export interface DeprecatedEventUsage {
 
 export type DeprecatedUsage = DeprecatedEventUsage; // we can union type here later
 
-export interface LoadedResourceMetadata {}
+export interface LoadedResourceMetadata {
+    url: string; // the resources URL
+    initiatorType: string; // the type of resource that initiated the performance event (xmlhttprequest, css, img)
+    nextHopProtocol: string; // the network protocol used to fetch the resource, as identified by the ALPN Protocol ID (RFC7301).
+}
 
 export interface LoadedResourceMetaDataBatch {
     resources: LoadedResourceMetadata[];

--- a/packages/ui-extensions-sdk/src/types.ts
+++ b/packages/ui-extensions-sdk/src/types.ts
@@ -341,3 +341,11 @@ export interface DeprecatedEventUsage {
 }
 
 export type DeprecatedUsage = DeprecatedEventUsage; // we can union type here later
+
+export interface LoadedResourceMetadata {}
+
+export interface LoadedResourceMetaDataBatch {
+    resources: LoadedResourceMetadata[];
+}
+
+export interface NetworkRequestMetadata {}

--- a/packages/ui-extensions-sdk/src/utils/security.test.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.test.ts
@@ -1,12 +1,9 @@
-import { collectResourceUsage } from './security';
+import { parseResource } from './security';
 
 const now = Date.now();
 
-const performance = {
-    getEntriesByType: jest.fn(),
-    timeOrigin: now
-};
-
+// mock performance.timeOrigin
+const performance = { timeOrigin: now };
 Object.defineProperty(window, 'performance', {
     configurable: true,
     enumerable: true,
@@ -56,72 +53,30 @@ const fakeRequestResource: PerformanceResourceTiming = {
     }
 };
 
-beforeEach(() => {
-    performance.getEntriesByType.mockReset();
-});
-
-describe('collectResourceUsage', () => {
-    it('returns empty result if getEntriesByType is empty', () => {
-        performance.getEntriesByType.mockReturnValueOnce([]);
-        const [batch, newIds] = collectResourceUsage(new Set());
-        expect(batch).toEqual({ resources: [] });
-        expect(newIds).toEqual(new Set());
-    });
-
-    it('returns empty result if getEntriesByType returns already seen resources', () => {
-        performance.getEntriesByType.mockReturnValueOnce([
-            fakeImageResource,
-            fakeRequestResource
-        ]);
-        const alreadySeen = new Set([
-            'http://localhost/image/1',
-            'http://localhost/api/1'
-        ]);
-        const [batch, newIds] = collectResourceUsage(alreadySeen);
-        expect(batch).toEqual({ resources: [] });
-        expect(newIds).toEqual(alreadySeen);
-    });
-
-    it('returns image resource not found before', () => {
-        performance.getEntriesByType.mockReturnValueOnce([fakeImageResource]);
-        const [batch, newIds] = collectResourceUsage(
-            new Set(['http://localhost/image/2'])
-        );
-        expect(batch).toEqual({
-            resources: [
-                {
-                    startTimeTs: now + fakeResourceTimingValues.startTime,
-                    secureConnectionStartTs:
-                        now + fakeResourceTimingValues.secureConnectionStart,
-                    url: 'http://localhost/image/1',
-                    urlHostname: 'localhost',
-                    initiatorType: 'image',
-                    nextHopProtocol: fakeResourceTimingValues.nextHopProtocol,
-                    duration: fakeResourceTimingValues.duration,
-                    decodedBodySize: fakeResourceTimingValues.decodedBodySize
-                }
-            ]
+describe('collectResourceUsage.parseResource', () => {
+    it('cast a image resource to PerformanceResourceTiming with url', () => {
+        expect(parseResource(fakeImageResource)).toEqual({
+            startTimeTs: now + fakeResourceTimingValues.startTime,
+            secureConnectionStartTs:
+                now + fakeResourceTimingValues.secureConnectionStart,
+            url: 'http://localhost/image/1',
+            urlHostname: 'localhost',
+            initiatorType: 'image',
+            nextHopProtocol: fakeResourceTimingValues.nextHopProtocol,
+            duration: fakeResourceTimingValues.duration,
+            decodedBodySize: fakeResourceTimingValues.decodedBodySize
         });
-        expect(newIds).toEqual(new Set(['http://localhost/image/1']));
     });
-
-    it('returns fetch resource not found before, and redact URL field', () => {
-        performance.getEntriesByType.mockReturnValueOnce([fakeRequestResource]);
-        const [batch, newIds] = collectResourceUsage(new Set());
-        expect(batch).toEqual({
-            resources: [
-                {
-                    startTimeTs: now + fakeResourceTimingValues.startTime,
-                    secureConnectionStartTs:
-                        now + fakeResourceTimingValues.secureConnectionStart,
-                    urlHostname: 'localhost',
-                    initiatorType: 'fetch',
-                    nextHopProtocol: fakeResourceTimingValues.nextHopProtocol,
-                    duration: fakeResourceTimingValues.duration,
-                    decodedBodySize: fakeResourceTimingValues.decodedBodySize
-                }
-            ]
+    it('cast a request resource to PerformanceResourceTiming without url', () => {
+        expect(parseResource(fakeRequestResource)).toEqual({
+            startTimeTs: now + fakeResourceTimingValues.startTime,
+            secureConnectionStartTs:
+                now + fakeResourceTimingValues.secureConnectionStart,
+            urlHostname: 'localhost',
+            initiatorType: 'fetch',
+            nextHopProtocol: fakeResourceTimingValues.nextHopProtocol,
+            duration: fakeResourceTimingValues.duration,
+            decodedBodySize: fakeResourceTimingValues.decodedBodySize
         });
-        expect(newIds).toEqual(new Set(['http://localhost/api/1']));
     });
 });

--- a/packages/ui-extensions-sdk/src/utils/security.test.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.test.ts
@@ -1,0 +1,127 @@
+import { collectResourceUsage } from './security';
+
+const now = Date.now();
+
+const performance = {
+    getEntriesByType: jest.fn(),
+    timeOrigin: now
+};
+
+Object.defineProperty(window, 'performance', {
+    configurable: true,
+    enumerable: true,
+    value: performance,
+    writable: true
+});
+
+const fakeResourceTimingValues = {
+    connectStart: now + 1,
+    connectEnd: now + 1,
+    domainLookupStart: now + 1,
+    domainLookupEnd: now + 1,
+    fetchStart: now + 1,
+    redirectEnd: 0,
+    redirectStart: 0,
+    requestStart: now + 1,
+    responseStart: now + 2,
+    responseEnd: now + 30,
+    secureConnectionStart: 0,
+    decodedBodySize: 0,
+    encodedBodySize: 0,
+    nextHopProtocol: 'http',
+    serverTiming: [],
+    transferSize: 0,
+    workerStart: 0,
+    toJSON() {
+        throw new Error('Function not implemented.');
+    },
+    duration: 0,
+    startTime: 0,
+    entryType: 'resource'
+};
+
+const fakeImageResource: PerformanceResourceTiming = {
+    ...fakeResourceTimingValues,
+    ...{
+        initiatorType: 'image',
+        name: 'http://localhost/image/1'
+    }
+};
+
+const fakeRequestResource: PerformanceResourceTiming = {
+    ...fakeResourceTimingValues,
+    ...{
+        initiatorType: 'fetch',
+        name: 'http://localhost/api/1'
+    }
+};
+
+beforeEach(() => {
+    performance.getEntriesByType.mockReset();
+});
+
+describe('collectResourceUsage', () => {
+    it('returns empty result if getEntriesByType is empty', () => {
+        performance.getEntriesByType.mockReturnValueOnce([]);
+        const [batch, newIds] = collectResourceUsage(new Set());
+        expect(batch).toEqual({ resources: [] });
+        expect(newIds).toEqual(new Set());
+    });
+
+    it('returns empty result if getEntriesByType returns already seen resources', () => {
+        performance.getEntriesByType.mockReturnValueOnce([
+            fakeImageResource,
+            fakeRequestResource
+        ]);
+        const alreadySeen = new Set([
+            'http://localhost/image/1',
+            'http://localhost/api/1'
+        ]);
+        const [batch, newIds] = collectResourceUsage(alreadySeen);
+        expect(batch).toEqual({ resources: [] });
+        expect(newIds).toEqual(alreadySeen);
+    });
+
+    it('returns image resource not found before', () => {
+        performance.getEntriesByType.mockReturnValueOnce([fakeImageResource]);
+        const [batch, newIds] = collectResourceUsage(
+            new Set(['http://localhost/image/2'])
+        );
+        expect(batch).toEqual({
+            resources: [
+                {
+                    startTimeTs: now + fakeResourceTimingValues.startTime,
+                    secureConnectionStartTs:
+                        now + fakeResourceTimingValues.secureConnectionStart,
+                    url: 'http://localhost/image/1',
+                    urlHostname: 'localhost',
+                    initiatorType: 'image',
+                    nextHopProtocol: fakeResourceTimingValues.nextHopProtocol,
+                    duration: fakeResourceTimingValues.duration,
+                    decodedBodySize: fakeResourceTimingValues.decodedBodySize
+                }
+            ]
+        });
+        expect(newIds).toEqual(new Set(['http://localhost/image/1']));
+    });
+
+    it('returns fetch resource not found before, and redact URL field', () => {
+        performance.getEntriesByType.mockReturnValueOnce([fakeRequestResource]);
+        const [batch, newIds] = collectResourceUsage(new Set());
+        expect(batch).toEqual({
+            resources: [
+                {
+                    startTimeTs: now + fakeResourceTimingValues.startTime,
+                    secureConnectionStartTs:
+                        now + fakeResourceTimingValues.secureConnectionStart,
+                    urlHostname: 'localhost',
+                    initiatorType: 'fetch',
+                    nextHopProtocol: fakeResourceTimingValues.nextHopProtocol,
+                    duration: fakeResourceTimingValues.duration,
+                    decodedBodySize: fakeResourceTimingValues.decodedBodySize
+                }
+            ]
+        });
+        expect(newIds).toEqual(new Set(['http://localhost/api/1']));
+    });
+});

--- a/packages/ui-extensions-sdk/src/utils/security.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.ts
@@ -1,7 +1,4 @@
-import { RESOURCE_BATCH_INTERVAL } from '../constants';
-import { LoadedResourceMetaDataBatch } from '../types';
-
-import { setImmediateInterval } from './utils';
+import { LoadedResourceMetadata, LoadedResourceMetaDataBatch } from '../types';
 
 export type LoadedResourceIds = Set<string>;
 
@@ -22,76 +19,51 @@ const isRequestKind = (timing: PerformanceResourceTiming) => {
     );
 };
 
-export const collectResourceUsage = (
-    previouslyLoadedResources: LoadedResourceIds
-): [LoadedResourceMetaDataBatch, LoadedResourceIds] => {
-    // Use resource timing api to to retrieve application loaded resources
-    const snapshot = performance.getEntriesByType('resource');
-
-    const resources = snapshot
-        .filter(isResourceTimingEntry)
-        // to avoid collecting the same resource twice, we use
-        // the Set difference: snapshot - previousSnapshot
-        .filter(r => !previouslyLoadedResources.has(r.name))
-        .map(r => {
-            // safe because r.name represents the resolved URL of the requested resource.
-            const urlHostname = new URL(r.name).hostname;
-            const ts = performance.timeOrigin;
-            let url;
-            if (!isRequestKind(r)) {
-                // for privacy reason we do not capture full URLs of network calls
-                url = r.name;
-            }
-            return {
-                startTimeTs: ts + r.startTime,
-                secureConnectionStartTs: ts + r.secureConnectionStart,
-                url,
-                urlHostname,
-                initiatorType: r.initiatorType,
-                nextHopProtocol: r.nextHopProtocol,
-                duration: r.duration,
-                decodedBodySize: r.decodedBodySize
-            };
-        });
-
-    return [{ resources }, new Set(snapshot.map(r => r.name))];
+export const parseResource = (
+    r: PerformanceResourceTiming
+): LoadedResourceMetadata => {
+    // safe because r.name represents the resolved URL of the requested resource.
+    const urlHostname = new URL(r.name).hostname;
+    const ts = performance.timeOrigin;
+    let url;
+    if (!isRequestKind(r)) {
+        // for privacy reason we do not capture full URLs of network calls
+        url = r.name;
+    }
+    return {
+        startTimeTs: ts + r.startTime,
+        secureConnectionStartTs: ts + r.secureConnectionStart,
+        url,
+        urlHostname,
+        initiatorType: r.initiatorType,
+        nextHopProtocol: r.nextHopProtocol,
+        duration: r.duration,
+        decodedBodySize: r.decodedBodySize
+    };
 };
 
 export const startResourceMonitoring = (
     reportUsage: (batch: LoadedResourceMetaDataBatch) => void
 ): (() => void) => {
-    let loadedResourceIds: LoadedResourceIds = new Set();
-
     if (!isPerformanceObjectSupported()) {
         return () => {};
     }
 
-    const doResourceCollection = () => {
-        // collect batch of resource-loading data
-        const [batch, newIds] = collectResourceUsage(loadedResourceIds);
-
-        // update index of loaded resources
-        loadedResourceIds = newIds;
-
-        // send to web-ui
-        reportUsage(batch);
+    const observerCallback = (entries: PerformanceObserverEntryList) => {
+        const resources = entries
+            .getEntries()
+            .filter(isResourceTimingEntry)
+            .map(parseResource);
+        return reportUsage({ resources });
     };
 
-    const interval = setImmediateInterval(() => {
-        try {
-            doResourceCollection();
-        } catch (e) {
-            // Stop batch collecting if there's an error
-            clearInterval(interval);
-        }
-    }, RESOURCE_BATCH_INTERVAL);
+    const observer = new PerformanceObserver(observerCallback);
+    observer.observe({ type: 'resource', buffered: true });
 
     let bufferFullHandler = () => {};
 
     if ('addEventListener' in performance) {
         bufferFullHandler = () => {
-            // ensure we collect the last resources before clearing the buffer
-            doResourceCollection();
             performance.clearResourceTimings();
         };
 
@@ -102,7 +74,7 @@ export const startResourceMonitoring = (
     }
 
     return () => {
-        clearInterval(interval);
+        observer.disconnect();
         if ('addEventListener' in performance) {
             performance.removeEventListener(
                 'resourcetimingbufferfull',

--- a/packages/ui-extensions-sdk/src/utils/security.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.ts
@@ -2,6 +2,13 @@ import { LoadedResourceMetaDataBatch, NetworkRequestMetadata } from '../types';
 
 export type LoadedResourceIds = Set<string>;
 
+function isRequestKind(timing: PerformanceResourceTiming) {
+    return (
+        timing.initiatorType === 'xmlhttprequest' ||
+        timing.initiatorType === 'fetch'
+    );
+}
+
 export const collectResourceUsage = (
     previouslyLoadedResources: LoadedResourceIds
 ): [LoadedResourceMetaDataBatch, LoadedResourceIds] => {
@@ -16,10 +23,7 @@ export const collectResourceUsage = (
             const a = e as PerformanceResourceTiming;
             const urlHostname = new URL(a.name).hostname;
             let url;
-            if (
-                a.initiatorType !== 'fetch' &&
-                a.initiatorType !== 'xhrequest'
-            ) {
+            if (!isRequestKind(a)) {
                 // for privacy reason we do not capture full URLs of network calls
                 url = a.name;
             }

--- a/packages/ui-extensions-sdk/src/utils/security.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.ts
@@ -58,7 +58,7 @@ export const collectResourceUsage = (
 };
 
 export const startResourceMonitoring = (
-    reportUsage: (batch: LoadedResourceMetaDataBatch) => Promise<void>
+    reportUsage: (batch: LoadedResourceMetaDataBatch) => void
 ): (() => void) => {
     let loadedResourceIds: LoadedResourceIds = new Set();
 
@@ -66,7 +66,7 @@ export const startResourceMonitoring = (
         return () => {};
     }
 
-    const doResourceCollection = async () => {
+    const doResourceCollection = () => {
         // collect batch of resource-loading data
         const [batch, newIds] = collectResourceUsage(loadedResourceIds);
 
@@ -74,24 +74,24 @@ export const startResourceMonitoring = (
         loadedResourceIds = newIds;
 
         // send to web-ui
-        await reportUsage(batch);
+        reportUsage(batch);
     };
 
-    const interval = setImmediateInterval(async () => {
+    const interval = setImmediateInterval(() => {
         try {
-            await doResourceCollection();
+            doResourceCollection();
         } catch (e) {
             // Stop batch collecting if there's an error
             clearInterval(interval);
         }
     }, RESOURCE_BATCH_INTERVAL);
 
-    let bufferFullHandler = async () => {};
+    let bufferFullHandler = () => {};
 
     if ('addEventListener' in performance) {
-        bufferFullHandler = async () => {
+        bufferFullHandler = () => {
             // ensure we collect the last resources before clearing the buffer
-            await doResourceCollection();
+            doResourceCollection();
             performance.clearResourceTimings();
         };
 

--- a/packages/ui-extensions-sdk/src/utils/security.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.ts
@@ -6,23 +6,32 @@ export const collectResourceUsage = (
     previouslyLoadedResources: LoadedResourceIds
 ): [LoadedResourceMetaDataBatch, LoadedResourceIds] => {
     // Use resource timing api to to retrieve application loaded resources
-
-    const snapshot = performance.getEntriesByType('resource').map(e => {
-        const a = e as PerformanceResourceTiming;
-        return {
-            url: a.name,
-            initiatorType: a.initiatorType,
-            nextHopProtocol: a.nextHopProtocol
-        };
-    });
+    const snapshot = performance.getEntriesByType('resource');
 
     // to avoid collecting the same resource twice, we use
     // the Set difference: snapshot - previouslyLoadedResources
-    const resources = snapshot.filter(
-        r => !previouslyLoadedResources.has(r.url)
-    );
+    const resources = snapshot
+        .filter(r => !previouslyLoadedResources.has(r.name))
+        .map(e => {
+            const a = e as PerformanceResourceTiming;
+            const urlHostname = new URL(a.name).hostname;
+            let url;
+            if (
+                a.initiatorType !== 'fetch' &&
+                a.initiatorType !== 'xhrequest'
+            ) {
+                // for privacy reason we do not capture full URLs of network calls
+                url = a.name;
+            }
+            return {
+                url,
+                urlHostname,
+                initiatorType: a.initiatorType,
+                nextHopProtocol: a.nextHopProtocol
+            };
+        });
 
-    return [{ resources }, new Set(snapshot.map(x => x.url))];
+    return [{ resources }, new Set(snapshot.map(x => x.name))];
 };
 
 export const registerNetworkRequestListeners = (

--- a/packages/ui-extensions-sdk/src/utils/security.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.ts
@@ -1,13 +1,26 @@
+import { RESOURCE_BATCH_INTERVAL } from '../constants';
 import { LoadedResourceMetaDataBatch } from '../types';
+
+import { setImmediateInterval } from './utils';
 
 export type LoadedResourceIds = Set<string>;
 
-function isRequestKind(timing: PerformanceResourceTiming) {
+const isPerformanceObjectSupported = () => {
+    return window.performance !== undefined && 'getEntries' in performance;
+};
+
+const isResourceTimingEntry = (
+    entry: PerformanceEntry
+): entry is PerformanceResourceTiming => {
+    return entry.entryType === 'resource';
+};
+
+const isRequestKind = (timing: PerformanceResourceTiming) => {
     return (
         timing.initiatorType === 'xmlhttprequest' ||
         timing.initiatorType === 'fetch'
     );
-}
+};
 
 export const collectResourceUsage = (
     previouslyLoadedResources: LoadedResourceIds
@@ -16,10 +29,10 @@ export const collectResourceUsage = (
     const snapshot = performance.getEntriesByType('resource');
 
     const resources = snapshot
+        .filter(isResourceTimingEntry)
         // to avoid collecting the same resource twice, we use
         // the Set difference: snapshot - previousSnapshot
         .filter(r => !previouslyLoadedResources.has(r.name))
-        .map(r => r as PerformanceNavigationTiming)
         .map(r => {
             // safe because r.name represents the resolved URL of the requested resource.
             const urlHostname = new URL(r.name).hostname;
@@ -42,4 +55,59 @@ export const collectResourceUsage = (
         });
 
     return [{ resources }, new Set(snapshot.map(r => r.name))];
+};
+
+export const startResourceMonitoring = (
+    reportUsage: (batch: LoadedResourceMetaDataBatch) => Promise<void>
+): (() => void) => {
+    let loadedResourceIds: LoadedResourceIds = new Set();
+
+    if (isPerformanceObjectSupported()) {
+        return () => {};
+    }
+
+    const doResourceCollection = async () => {
+        // collect batch of resource-loading data
+        const [batch, newIds] = collectResourceUsage(loadedResourceIds);
+
+        // update index of loaded resources
+        loadedResourceIds = newIds;
+
+        // send to web-ui
+        await reportUsage(batch);
+    };
+
+    const interval = setImmediateInterval(async () => {
+        try {
+            await doResourceCollection();
+        } catch (e) {
+            // Stop batch collecting if there's an error
+            clearInterval(interval);
+        }
+    }, RESOURCE_BATCH_INTERVAL);
+
+    let bufferFullHandler = async () => {};
+
+    if ('addEventListener' in performance) {
+        bufferFullHandler = async () => {
+            // ensure we collect the last resources before clearing the buffer
+            await doResourceCollection();
+            performance.clearResourceTimings();
+        };
+
+        performance.addEventListener(
+            'resourcetimingbufferfull',
+            bufferFullHandler
+        );
+    }
+
+    return () => {
+        clearInterval(interval);
+        if ('addEventListener' in performance) {
+            performance.removeEventListener(
+                'resourcetimingbufferfull',
+                bufferFullHandler
+            );
+        }
+    };
 };

--- a/packages/ui-extensions-sdk/src/utils/security.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.ts
@@ -1,0 +1,29 @@
+import { LoadedResourceMetaDataBatch, NetworkRequestMetadata } from '../types';
+
+// TODO: Feel free to pass in whatever data structure you need
+// to track what has been previously loaded. Here I'm assuming it will be a set of
+// string ids
+export type LoadedResourceIds = Set<string>;
+
+export const collectResourceUsage = (
+    previouslyLoadedResources: LoadedResourceIds
+): [LoadedResourceMetaDataBatch, LoadedResourceIds] => {
+    const newLoadedResourceIds = new Set(previouslyLoadedResources);
+
+    // TODO: Do batch collection of resource data
+    // TODO: Update list of preivously loaded resource ids
+
+    return [{ resources: [] }, newLoadedResourceIds];
+};
+
+export const registerNetworkRequestListeners = (
+    onNetworkRequest: (request: NetworkRequestMetadata) => void
+): (() => void) => {
+    // TODO: monitor network requests, call `onNetworkRequest' as needed
+    // onNetworkRequest({});
+
+    // TODO: It's good practice to return a 'cleanup' hook that removes the event listeners you've set up
+    return () => {
+        // remove listeners
+    };
+};

--- a/packages/ui-extensions-sdk/src/utils/security.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.ts
@@ -1,4 +1,4 @@
-import { LoadedResourceMetaDataBatch, NetworkRequestMetadata } from '../types';
+import { LoadedResourceMetaDataBatch } from '../types';
 
 export type LoadedResourceIds = Set<string>;
 
@@ -41,16 +41,4 @@ export const collectResourceUsage = (
         });
 
     return [{ resources }, new Set(snapshot.map(r => r.name))];
-};
-
-export const registerNetworkRequestListeners = (
-    onNetworkRequest: (request: NetworkRequestMetadata) => void
-): (() => void) => {
-    // TODO: monitor network requests, call `onNetworkRequest' as needed
-    // onNetworkRequest({});
-
-    // TODO: It's good practice to return a 'cleanup' hook that removes the event listeners you've set up
-    return () => {
-        // remove listeners
-    };
 };

--- a/packages/ui-extensions-sdk/src/utils/security.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.ts
@@ -62,7 +62,7 @@ export const startResourceMonitoring = (
 ): (() => void) => {
     let loadedResourceIds: LoadedResourceIds = new Set();
 
-    if (isPerformanceObjectSupported()) {
+    if (!isPerformanceObjectSupported()) {
         return () => {};
     }
 

--- a/packages/ui-extensions-sdk/src/utils/security.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.ts
@@ -21,6 +21,7 @@ export const collectResourceUsage = (
         .filter(r => !previouslyLoadedResources.has(r.name))
         .map(r => r as PerformanceNavigationTiming)
         .map(r => {
+            // safe because r.name represents the resolved URL of the requested resource.
             const urlHostname = new URL(r.name).hostname;
             const ts = performance.timeOrigin;
             let url;

--- a/packages/ui-extensions-sdk/src/utils/security.ts
+++ b/packages/ui-extensions-sdk/src/utils/security.ts
@@ -22,18 +22,21 @@ export const collectResourceUsage = (
         .map(r => r as PerformanceNavigationTiming)
         .map(r => {
             const urlHostname = new URL(r.name).hostname;
-            const timestamp = performance.timeOrigin + r.startTime;
+            const ts = performance.timeOrigin;
             let url;
             if (!isRequestKind(r)) {
                 // for privacy reason we do not capture full URLs of network calls
                 url = r.name;
             }
             return {
-                timestamp,
+                startTimeTs: ts + r.startTime,
+                secureConnectionStartTs: ts + r.secureConnectionStart,
                 url,
                 urlHostname,
                 initiatorType: r.initiatorType,
-                nextHopProtocol: r.nextHopProtocol
+                nextHopProtocol: r.nextHopProtocol,
+                duration: r.duration,
+                decodedBodySize: r.decodedBodySize
             };
         });
 

--- a/packages/ui-extensions-sdk/src/utils/utils.ts
+++ b/packages/ui-extensions-sdk/src/utils/utils.ts
@@ -71,3 +71,12 @@ export const validateKey = <T = any>(definition: T): boolean => {
 
     return true;
 };
+
+export const setImmediateInterval = (
+    callback: () => unknown,
+    timeout: number
+) => {
+    callback();
+
+    return setInterval(callback, timeout);
+};


### PR DESCRIPTION
Network resource monitoring

this PR adds monitoring of all network resources loaded via the performance api. Collection is done in batches and reported back to web-ui for logging every 10 seconds with an event.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/ui-extensions-sdk@0.31.1-canary.124.2dcecab.0
  # or 
  yarn add @datadog/ui-extensions-sdk@0.31.1-canary.124.2dcecab.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
