### PR TITLE
Run CI on `pull_request` events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Continuous Integration
 
 on:
+    - pull_request
     - push
 
 jobs:


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- We recently made some status checks required. This is what we wanted, but our current GitHub actions setup only works for `push` events. Since we have a GitHub Action that opens up PRs from outside the repo, we want the CI workflow to run on `pull_request` events. E.g. Look at https://github.com/DataDog/apps/pull/129. It isn't able to be merged because the CI check isn't run.
    Honestly, this was a mistake in our infrastructure that we never noticed up until now. So really, we're just fixing something that hasn't been working up until now.

## Changes

- We make the CI check run on both pushes and Pull Requests.

## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

- N/A

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [x] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.
