### PR TITLE
chore: add caching of yarn deps to CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: Continuous Integration
 on:
     - pull_request
     - push
+    - workflow_dispatch
+
+concurrency:
+    group: ${{ github.ref }}-ci
+    cancel-in-progress: true
 
 jobs:
     ci:
@@ -12,13 +17,14 @@ jobs:
 
         steps:
             - name: checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: install node
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
-                  node-version: 16.3.0
+                  node-version-file: '.node-version'
+                  cache: 'yarn'
             - name: install
-              run: yarn
+              run: yarn --prefer-offline
             - name: lint
               run: yarn lint
             - name: build

--- a/.github/workflows/publish-api-documentation.yml
+++ b/.github/workflows/publish-api-documentation.yml
@@ -5,20 +5,25 @@ on:
         branches:
             - master
 
+concurrency:
+    group: ${{ github.ref }}-api-docs
+    cancel-in-progress: true
+
 jobs:
     publish:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup Node.js
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
-                  node-version: 16.3.0
+                  node-version-file: '.node-version'
+                  cache: 'yarn'
 
             - name: Install dependencies
-              run: yarn install
+              run: yarn install --prefer-offline
 
             - name: Build all packages
               run: yarn build

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -5,25 +5,29 @@ on:
             - 'gh-pages'
             - master
 
+concurrency:
+    group: ${{ github.ref }}-canary
+    cancel-in-progress: true
+
 jobs:
     publish:
         runs-on: ubuntu-latest
         if: "!contains(github.event.head_commit.message, 'skip canary')"
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Prepare repository
               run: git fetch --unshallow --tags
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16.3.0
+                  node-version-file: '.node-version'
+                  cache: 'yarn'
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@datadog'
-            - run: yarn
+            - name: install
+              run: yarn --prefer-offline
             - run: yarn build
-            - name: Add auth credentials for lerna
-              run: npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-              env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
             - run: yarn release:canary
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -5,30 +5,32 @@ on:
         branches:
             - master
 
+concurrency:
+    group: ${{ github.ref }}-publish
+    cancel-in-progress: true
+
 jobs:
     publish:
         runs-on: ubuntu-latest
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         steps:
             - name: Checkout repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup Node.js
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
-                  node-version: 16.3.0
+                  node-version-file: '.node-version'
+                  cache: 'yarn'
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@datadog'
 
             - name: Install dependencies
-              run: yarn
+              run: yarn --prefer-offline
 
             - name: Build packages
               run: yarn build
-
-            - name: Add auth credentials for npm
-              run: npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-              env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Create release Pull Request or publish to npm
               id: changesets

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 dist
 .DS_Store
+.npmrc

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@
 **/dist
 CHANGELOG.md
 docs
+**/*.handlebars

--- a/packages/create-app/src/template/.prettierignore
+++ b/packages/create-app/src/template/.prettierignore
@@ -1,1 +1,2 @@
 build
+*.handlebars


### PR DESCRIPTION
## Motivation

-   Speed up GitHub Actions and reduce the impact of downloading dependencies every time an Action runs.

## Changes

-   Caches the yarn cache directory in CI and tells `yarn install` to `--prefer-offline`

## Testing

Manually trigger a `Continuous Integration` GitHub Action and notice that with the same `yarn.lock` file dependencies are not downloaded again

## Releases

Choose one:

-   [x] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/create-app@1.2.1-canary.132.1b441a1.0
  npm install @datadog/framepost@0.3.2-canary.132.1b441a1.0
  npm install @datadog/ui-extensions-react@0.30.2-canary.132.1b441a1.0
  npm install @datadog/ui-extensions-sdk@0.30.2-canary.132.1b441a1.0
  # or 
  yarn add @datadog/create-app@1.2.1-canary.132.1b441a1.0
  yarn add @datadog/framepost@0.3.2-canary.132.1b441a1.0
  yarn add @datadog/ui-extensions-react@0.30.2-canary.132.1b441a1.0
  yarn add @datadog/ui-extensions-sdk@0.30.2-canary.132.1b441a1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
