### PR TITLE
[UIAPPS-181] Add Org Settings Documentation

### DIFF
--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -55,14 +55,14 @@ See the [Developer Platform Developer Guide][3] for details about this architect
 
 6. You are then presented with the dashboard for your new application. You can further change your app name here, give your app a more detailed description, or change its icon.
 
-<img style="max-width:80%" alt="App Settings Dashboard" src="https://user-images.githubusercontent.com/228230/137548724-0487c169-9b65-4b31-bfa6-f8da3bbd2785.png">
+<img style="max-width:80%" alt="App Settings Dashboard" src="https://user-images.githubusercontent.com/17037651/161887740-cbf5a3ab-fab3-4910-bd9f-a5bbd817c6da.png">
 
 
 ### Add your app to a dashboard
 
 1. Before you can add your app to a dashboard, you must enable it by clicking on **UI Extensions** on the left side.
 
-<img style="max-width:80%" alt="Enable UI Extensions" src="https://user-images.githubusercontent.com/228230/137548823-0ad7f1ae-512f-44a4-93ca-c2aa3c47b992.png">
+<img style="max-width:80%" alt="Enable UI Extensions" src="https://user-images.githubusercontent.com/17037651/161887839-ad2b6112-2dbf-4e9e-a111-852b6f1d49d5.png">
 
 Once this view loads, click on the **Enable UI Extensions** button. 
 
@@ -71,9 +71,9 @@ Once this view loads, click on the **Enable UI Extensions** button.
 Make sure you change the root URL and debug mode root URL to match the localhost version of the widget that you have running. The main controller path is `/widget`. These URL values will change as you build your application and begin to host it on your own infrastructure.
 
 3. Turn the toggle 
-to ‘Dashboard Custom Widget’ on. This generates JSON on the right hand side. 
+to ‘Dashboard Custom Widget’ on (you may need to scroll the center panel down a bit to see it). This generates JSON on the right hand side. 
 
-<img style="max-width:80%" alt="Dashboard Custom Widget" src="https://user-images.githubusercontent.com/228230/137549275-f901e4c1-16ad-4c82-95f3-9ba7f346c9ba.png">
+<img style="max-width:80%" alt="Dashboard Custom Widget" src="https://user-images.githubusercontent.com/17037651/161888025-bb7a6109-51a8-47c6-83a0-21216b66e427.png">
 
 
 Note that this JSON contains a value called `Your first widget`. This is the name of your widget as it appears in the menu to add to your Dashboards.

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -55,14 +55,14 @@ See the [Developer Platform Developer Guide][3] for details about this architect
 
 6. You are then presented with the dashboard for your new application. You can further change your app name here, give your app a more detailed description, or change its icon.
 
-<img style="max-width:80%" alt="App Settings Dashboard" src="https://user-images.githubusercontent.com/17037651/161887740-cbf5a3ab-fab3-4910-bd9f-a5bbd817c6da.png">
+<img style="max-width:80%" alt="App Edit Basic Information" src="https://user-images.githubusercontent.com/17037651/163401812-d21a9d3a-e73f-49b0-bda4-e7c447295784.png">
 
 
 ### Add your app to a dashboard
 
 1. Before you can add your app to a dashboard, you must enable it by clicking on **UI Extensions** on the left side.
 
-<img style="max-width:80%" alt="Enable UI Extensions" src="https://user-images.githubusercontent.com/17037651/161887839-ad2b6112-2dbf-4e9e-a111-852b6f1d49d5.png">
+<img style="max-width:80%" alt="App Edit Enable UI Extensions" src="https://user-images.githubusercontent.com/17037651/163401958-153f6c80-d7ba-4b47-a40d-1cf08913602d.png">
 
 Once this view loads, click on the **Enable UI Extensions** button. 
 
@@ -73,7 +73,7 @@ Make sure you change the root URL and debug mode root URL to match the localhost
 3. Turn the toggle 
 to ‘Dashboard Custom Widget’ on (you may need to scroll the center panel down a bit to see it). This generates JSON on the right hand side. 
 
-<img style="max-width:80%" alt="Dashboard Custom Widget" src="https://user-images.githubusercontent.com/17037651/161888025-bb7a6109-51a8-47c6-83a0-21216b66e427.png">
+<img style="max-width:80%" alt="App Edit UI Extensions" src="https://user-images.githubusercontent.com/17037651/163402086-a3afbecd-c9c0-4608-bb91-6cb5391fec93.png">
 
 
 Note that this JSON contains a value called `Your first widget`. This is the name of your widget as it appears in the menu to add to your Dashboards.

--- a/docs/en/programming-model.md
+++ b/docs/en/programming-model.md
@@ -201,13 +201,13 @@ try {
 
 
 
-## Custom Configuration
+## Org Configuration
 
-If app behavior must be further tailored for specific orgs, custom user configurations can be enabled via the [Developer Platform][1]. To begin, navigate to the "User Configuration" tab of your app:
+If app behavior must be further tailored for specific orgs, custom org configurations can be enabled via the [Developer Platform][1]. To begin, navigate to the "Org Configuration" tab of your app:
 
-<img style="max-width:80%" alt="User Configuration" src="https://user-images.githubusercontent.com/17037651/161995079-e16913ee-42c8-4c66-b03d-d2e51fadf26c.png">
+<img style="max-width:80%" alt="App Edit Org Configuration" src="https://user-images.githubusercontent.com/17037651/163402644-8666caff-a987-4731-a2b2-d9b123baae39.png">
 
-On this page, you can define up to **20** settings that users can configure to customize your app's behavior; these configuration values can ultimately be retrieved within your app by using the `client.config.getConfig()` method in the SDK to implement the desired customization. Upon clicking the "Add New" drop-down button, you will be able to select from three options:
+On this page, you can define up to **20** settings that orgs can configure to customize your app's behavior; these configuration values can ultimately be retrieved within your app by using the `client.config.getOrgConfig()` method in the SDK to implement the desired customization. Upon clicking the "Add New" drop-down button, you will be able to select from three options:
 
   1. Boolean: a `boolean` field that will be rendered as a toggle switch to users; useful for turning on/off specific behavior within your app
   2. Input Field: a free-form `string` field rendered as an input field; can be used, for example, to define a custom on-premises URL that your app will fetch org data from — see the note below on credentials / secrets for caveats
@@ -221,10 +221,10 @@ All three options share the following keys:
   * `description`: text describing the behavior that a specific setting will modify; displayed to users when configuring your app
   * `default`: the default configuration value for a setting if the user has **not** already input one
     * In the case of a select field, the `default` **must** be one of the options associated with the `enum` key
-  * `required`: whether the field is required for the app to function; if set to `true`, users will **not** be able to use your app until they've configured the required setting
-    * While a setting with both a non-empty `default` value and `required: true` is valid, requiring the setting is unnecessary since the `default` value satisfies the `required: true` constraint even when the user has never configured the setting
+  * `required`: whether the field is required for the app to function; if set to `true`, orgs will **not** be able to use your app until they've configured the required setting
+    * While a setting with both a non-empty `default` value and `required: true` is valid, requiring the setting is unnecessary since the `default` value satisfies the `required: true` constraint even when the org has never configured the setting
 
-For a more concrete illustration, assuming that your app's custom configuration is defined as follows:
+For a more concrete illustration, assuming that your app's org configuration is defined as follows:
 
 ```JSON
 [
@@ -258,19 +258,19 @@ For a more concrete illustration, assuming that your app's custom configuration 
 
 An org using your app would see the following page to configure the settings you defined:
 
-<img style="max-width:80%" alt="Configuring an App" src="https://user-images.githubusercontent.com/17037651/161990413-7f5061b0-6577-4dc3-b775-cf6d14e864d8.png">
+<img style="max-width:80%" alt="App Configure Org Settings" src="https://user-images.githubusercontent.com/17037651/163403066-531c1225-5310-438d-b75a-40682c4ee61b.png">
 
 Back in your app, you could access configured values with the following:
 
 ```js
-const customConfig = await client.config.getConfig()
-/* customConfig = {
+const customOrgConfig = await client.config.getOrgConfig()
+/* customOrgConfig = {
   boolean_field: <boolean>,
   input_field: <string>,
   select_field: <string>
 } */
 
-switch (customConfig.select_field) {
+switch (customOrgConfig.select_field) {
   case 'choice_a':
     // do something
     break;
@@ -280,7 +280,7 @@ switch (customConfig.select_field) {
     break;
 
   default:
-    throw new Error(`Unrecognized value of 'select_field': ${customConfig.select_field}`)
+    throw new Error(`Unrecognized value of 'select_field': ${customOrgConfig.select_field}`)
 }
 ```
 

--- a/docs/en/programming-model.md
+++ b/docs/en/programming-model.md
@@ -201,6 +201,78 @@ try {
 
 
 
+## Custom Configuration
+
+If app behavior must be further tailored for specific orgs, custom user configurations can be enabled via the [Developer Platform][1]. To begin, navigate to the "User Configuration" tab of your app:
+
+<img style="max-width:80%" alt="User Configuration" src="https://user-images.githubusercontent.com/17037651/161995079-e16913ee-42c8-4c66-b03d-d2e51fadf26c.png">
+
+On this page, you can define up to **20** settings that users can configure to customize your app's behavior; these configuration values can ultimately be retrieved within your app by using the `client.config.getConfig()` method in the SDK to implement the desired customization. Upon clicking the "Add New" drop-down button, you will be able to select from three options:
+
+  1. Boolean: a `boolean` field that will be rendered as a toggle switch to users; useful for turning on/off specific behavior within your app
+  2. Input Field: a free-form `string` field rendered as an input field; can be used, for example, to define a custom on-premises URL that your app will fetch org data from — see the note below on credentials / secrets for caveats
+  3. Select Field: a `string` field, rendered as a drop down, that only accepts an option defined in the associated `enum` key; useful if orgs can only select a configuration from a number of pre-defined options
+
+**Important**: Configuration values should **never contain sensitive information**. This feature is **only for configuration** and as such, does not provide sufficient security to support storage of secrets and other sensitive information.
+
+All three options share the following keys:
+  * `key`: the **unique** key your app will use to refer to a particular configuration value
+  * `label`: the label text that users will see when configuring a particular setting
+  * `description`: text describing the behavior that a specific setting will modify; displayed to users when configuring your app
+  * `default`: the default configuration value for a setting if the user has **not** already input one
+    * In the case of a select field, the `default` **must** be one of the options associated with the `enum` key
+  * `required`: whether the field is required for the app to function; if set to `true`, users will **not** be able to use your app until they've configured the required setting
+    * While a setting with both a non-empty `default` value and `required: true` is valid, requiring the setting is unnecessary since the `default` value satisfies the `required: true` constraint even when the user has never configured the setting
+
+For a more concrete illustration, assuming that your app's custom configuration is defined as follows:
+
+```JSON
+[
+    {
+        "key": "boolean_field",
+        "label": "A Boolean Field",
+        "description": "A boolean field that controls app behavior",
+        "required": false,
+        "type": "boolean"
+    },
+    {
+        "key": "input_field",
+        "label": "An Input Field",
+        "description": "An input field that controls app behavior",
+        "required": false,
+        "type": "string"
+    },
+    {
+        "key": "select_field",
+        "label": "A Select Field",
+        "description": "A select field that controls app behavior",
+        "enum": [
+            "choice_a",
+            "choice_b"
+        ],
+        "required": false,
+        "type": "string"
+    }
+]
+```
+
+An org using your app would see the following page to configure the settings you defined:
+
+<img style="max-width:80%" alt="Configuring an App" src="https://user-images.githubusercontent.com/17037651/161990413-7f5061b0-6577-4dc3-b775-cf6d14e864d8.png">
+
+Back in your app, you could access configured values with the following:
+
+```js
+const customConfig = await client.config.getConfig()
+/* customConfig = {
+  boolean_field: <boolean>,
+  input_field: <string>,
+  select_field: <string>
+} */
+```
+
+**Note**: In this particular example, each of these fields can be `undefined` since none of them have `required: true` nor a `default` value.
+
 # UI Extensions
 
 ## Dashboard Custom Widget
@@ -746,3 +818,5 @@ client.resize({
 
 All fields are optional, and will be defaulted to the actual content dimensions.
 For example, if a modal is 1000px wide, and you only pass the height, the width will be computed to be 1000px.
+
+[1]: https://app.datadoghq.com/apps

--- a/docs/en/programming-model.md
+++ b/docs/en/programming-model.md
@@ -269,6 +269,19 @@ const customConfig = await client.config.getConfig()
   input_field: <string>,
   select_field: <string>
 } */
+
+switch (customConfig.select_field) {
+  case 'choice_a':
+    // do something
+    break;
+
+  case 'choice_b':
+    // do something else
+    break;
+
+  default:
+    throw new Error(`Unrecognized value of 'select_field': ${customConfig.select_field}`)
+}
 ```
 
 **Note**: In this particular example, each of these fields can be `undefined` since none of them have `required: true` nor a `default` value.


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

With the introduction of Org Settings, developers will need to learn how to define custom org settings users can configure.

<!-- - Is this a bugfix or a feature? -->

## Changes

This change updates the repo's existing documentation [to account for Org Settings](https://github.com/DataDog/apps/blob/wes.auyeung/uiapps-181-org-settings-docs/docs/en/programming-model.md#org-configuration).

## Testing

N/A

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [x] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/ui-extensions-sdk@0.31.1-canary.135.c02869b.0
  # or 
  yarn add @datadog/ui-extensions-sdk@0.31.1-canary.135.c02869b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
