### PR TITLE
fix: don't run eslint on Markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
         "test": "yarn test:example-packages && yarn test:fixed-packages && yarn workspaces run test"
     },
     "lint-staged": {
+        "*.{ts,tsx,js,jsx}": [
+            "eslint --fix"
+        ],
         "*.{ts,tsx,js,jsx,md,mdx}": [
-            "eslint --fix",
             "prettier --write"
         ]
     },


### PR DESCRIPTION
## Motivation

-   Just realized that we were running `eslint --fix` on `.md` files and that can have some unexpected errors

## Changes

- Stops linting `.md` and `.mdx` files

## Releases

Choose one:

-   [x] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.
