### PR TITLE
[UI Apps] Fix typo

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ The "canary" release can be used to test out some changes without fully merging 
 We use [`changesets`][] to help with normal package releases.
 
 [`changesets`][] will manage a long-running PR that batches changes together.
-When a normal PR is merged, [`changsets`][] will keep track of any [changeset][]s in this long-running PR.
+When a normal PR is merged, [`changesets`][] will keep track of any [changeset][]s in this long-running PR.
 When we're ready to release some number of packages, we can merge this long-running PR and [`changesets`][] will release all packages with a [changeset][].
 
 ## `@datadog/ui-extensions-*` packages


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

- We dropped an `e` and it made the link not render.

<!-- - Is this a bugfix or a feature? -->

## Changes

- We fix the typo

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [x] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/ui-extensions-sdk@0.31.2-canary.145.d31aa2c.0
  # or 
  yarn add @datadog/ui-extensions-sdk@0.31.2-canary.145.d31aa2c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
