### PR TITLE
Explain changeset versioning a bit better

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,14 @@ The "canary" release can be used to test out some changes without fully merging 
 We use [`changesets`][] to help with normal package releases.
 
 [`changesets`][] will manage a long-running PR that batches changes together.
+This PR will update all of the versions of packages in the repo that are affected.
+
+It's very likely that you'll see a large diff of version changes;
+this is normal.
+If the bulk of those changes are to `package.json` files,
+you should be fine.
+Feel free to ask for a second set of eyes if you are confused.
+
 When a normal PR is merged, [`changesets`][] will keep track of any [changeset][]s in this long-running PR.
 When we're ready to release some number of packages, we can merge this long-running PR and [`changesets`][] will release all packages with a [changeset][].
 


### PR DESCRIPTION
## Motivation

- We want to try and explain what's normal/expected.

## Changes

- We expand the documentation a bit.

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [x] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @datadog/ui-extensions-sdk@0.31.2-canary.147.3d9e5e9.0
  # or 
  yarn add @datadog/ui-extensions-sdk@0.31.2-canary.147.3d9e5e9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
