### PR TITLE
🐛 Build framepost for browser & node import

### DIFF
--- a/.changeset/witty-rats-sing.md
+++ b/.changeset/witty-rats-sing.md
@@ -1,0 +1,5 @@
+---
+'@datadog/framepost': minor
+---
+
+Build framepost for import by both the browser and node

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 dist
 .DS_Store
 .vscode/settings.json
+.idea

--- a/packages/framepost/package.json
+++ b/packages/framepost/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datadog/framepost",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Secure parent-child iframe communication",
     "homepage": "https://github.com/DataDog/apps/tree/master/packages/framepost",
     "repository": {

--- a/packages/framepost/webpack.config.js
+++ b/packages/framepost/webpack.config.js
@@ -9,7 +9,8 @@ module.exports = {
         filename: 'framepost.min.js',
         path: path.resolve(__dirname, 'dist'),
         library: 'framepost',
-        libraryTarget: 'umd'
+        libraryTarget: 'umd',
+        globalObject: 'this'
     },
     module: {
         rules: [


### PR DESCRIPTION
## Motivation

I'm currently migrating the Custom Widget component to the crosspage framework in [this PR](https://github.com/DataDog/web-ui/pull/72582).

As part of this work, custom widget was added to [the logic](https://github.com/DataDog/web-ui/pull/72582/files#diff-852608dd48bb80ddd6cb329ee4e86621df9910e37e8497091353f3c8108b319aR532) that calculates the widget title. To get a title for custom widgets, a new app manager is instantiated to retrieve the widget object. This code imports `framepost`. 

The same title generation code is also used in a set of [node unit tests](https://github.com/DataDog/web-ui/blob/preprod/services/mobile-widget-query/routes/get-computed-widgets/get-computed-widgets.unit.ts) related to the mobile platform (and, presumably, in the mobile code itself). Currently, these tests will fail at the point that `framepost` is imported with the error message 

```
ReferenceError: self is not defined

    > 1 | import { ClientDestroyedError } from '@datadog/framepost';
```

[You can see a failing build on the migration PR here](https://gitlab.ddbuild.io/DataDog/web-ui/-/jobs/196887726).

This happens because `framepost` is only built for the browser and not for consumption by node. 

## Changes

Updates the `globalObject` to be `this` rather than `self` (see [Webpack docs here](https://webpack.js.org/configuration/output/#outputglobalobject))

## Testing

I tested this locally, and the unit tests pass once this change is made.

The Webpack docs make it appear as though this has no negative side-effects for the browser release but, as I'm not totally familiar with how `framepost` is used, I'd appreciate some help testing.

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [x] All packages that need a release have a changeset.
