### PR TITLE
Added esm target ouput for ui extensions sdk

### DIFF
--- a/.changeset/rotten-mangos-count.md
+++ b/.changeset/rotten-mangos-count.md
@@ -1,0 +1,6 @@
+---
+'@datadog/ui-extensions-sdk': minor
+'@datadog/ui-extensions-react': minor
+---
+
+Add an esm output for ui-extensions-sdk

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "build": "yarn workspaces run build",
         "docs": "typedoc --options typedoc.js",
         "format": "prettier --write .",
-        "lint:check": "eslint '**/*.{ts,js}'",
+        "lint:check": "eslint \"**/*.{ts,js}\"",
         "lint:fix": "yarn run lint:check --fix",
         "lint": "yarn run lint:check && prettier --check .",
         "postinstall": "patch-package",

--- a/packages/ui-extensions-sdk/package.json
+++ b/packages/ui-extensions-sdk/package.json
@@ -9,6 +9,7 @@
         "directory": "packages/ui-extensions-sdk"
     },
     "main": "dist/ui-extensions-sdk.min.js",
+    "module": "dist/ui-extensions-sdk-esm.min.js",
     "browser": "dist/ui-extensions-sdk-esm.min.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/packages/ui-extensions-sdk/package.json
+++ b/packages/ui-extensions-sdk/package.json
@@ -9,6 +9,7 @@
         "directory": "packages/ui-extensions-sdk"
     },
     "main": "dist/ui-extensions-sdk.min.js",
+    "browser": "dist/ui-extensions-sdk-esm.min.js",
     "types": "dist/index.d.ts",
     "scripts": {
         "build": "webpack --mode production",

--- a/packages/ui-extensions-sdk/webpack.config.js
+++ b/packages/ui-extensions-sdk/webpack.config.js
@@ -1,46 +1,53 @@
 const path = require('path');
 const webpack = require('webpack');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const packageJson = require('./package.json');
 
-module.exports = (env, options) => {
-    const config = {
-        devtool: 'source-map',
-        target: ['web', 'es5'],
-        entry: './src/index.ts',
-        output: {
-            filename: 'ui-extensions-sdk.min.js',
-            path: path.resolve(__dirname, 'dist'),
-            library: 'DD_SDK',
-            libraryTarget: 'umd'
-        },
-        module: {
-            rules: [
-                {
-                    test: /\.tsx?$/,
-                    loader: 'ts-loader'
-                }
-            ]
-        },
-        plugins: [
-            new webpack.DefinePlugin({
-                SDK_VERSION: JSON.stringify(packageJson.version)
-            })
-        ],
-        resolve: {
-            extensions: ['.ts', '.tsx', '.js']
-        },
-        devServer: {
-            clientLogLevel: 'warning',
-            open: true,
-            historyApiFallback: true,
-            stats: 'errors-only'
-        }
-    };
+const config = {
+    devtool: 'source-map',
+    entry: './src/index.ts',
 
-    if (options.mode === 'production') {
-        config.plugins.push(new CleanWebpackPlugin());
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                loader: 'ts-loader'
+            }
+        ]
+    },
+    plugins: [
+        new webpack.DefinePlugin({
+            SDK_VERSION: JSON.stringify(packageJson.version)
+        })
+    ],
+    resolve: {
+        extensions: ['.ts', '.tsx', '.js']
+    },
+    devServer: {
+        clientLogLevel: 'warning',
+        open: true,
+        historyApiFallback: true,
+        stats: 'errors-only'
     }
-
-    return config;
 };
+
+const umdConfig = {
+    ...config,
+    target: ['web', 'es5'],
+    entry: './src/index.ts',
+    output: {
+        filename: 'ui-extensions-sdk.min.js',
+        path: path.resolve(__dirname, 'dist'),
+        library: 'DD_SDK',
+        libraryTarget: 'umd'
+    }
+};
+
+const esmConfig = {
+    ...config,
+    output: {
+        filename: 'ui-extensions-sdk-esm.min.js',
+        path: path.resolve(__dirname, 'dist')
+    }
+};
+
+module.exports = [umdConfig, esmConfig];


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

Modern build tools aren't compatible with UMD. 

<!-- - Is this a bugfix or a feature? -->

## Changes

Added an additional webpack config and assigned the esm output for "main" and "module"

## Testing

Run the build and ensure both ui-extensions.min.js and ui-extensions-esm.min.js are output

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [X] All packages that need a release have a changeset.
