### PR TITLE
Version Packages

### DIFF
--- a/.changeset/strong-colts-melt.md
+++ b/.changeset/strong-colts-melt.md
@@ -1,5 +1,0 @@
----
-'@datadog/create-app': patch
----
-
-update dependencies

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v1.0.1 (Fri Dec 17 2021)
 
+## 2.0.1
+
+### Patch Changes
+
+-   85cfd4c: update dependencies
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datadog/create-app",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "npm init package to create a Datadog App",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Motivation

Bumping package version to point to changes made in https://github.com/DataDog/apps/pull/165

## Changes

Bumps create-app to desired version (`2.0.1`)

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [x] All packages that need a release have a changeset.
