### PR TITLE
Update getting-started.md (aka ui_extensions.md )

### DIFF
--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -1,6 +1,5 @@
 ---
 title: Datadog UI Extensions
-kind: documentation
 further_reading:
   - link: "https://github.com/DataDog/apps/blob/master/docs/en/ui-extensions-design-guidelines.md"
     tag: "Github"


### PR DESCRIPTION
<!--  🎉 Hello there 🎉! Thank you for being a part of Datadog Apps! -->

## Motivation

-   What is the motivation / context for this change? (Text, screenshot, JIRA ticket, Github Issue)

<!-- - Is this a bugfix or a feature? -->
the `kind` param is no longer a user-defined frontmatter. it is built-in to be one of `home`, `page`, `section` [etc.](https://gohugo.io/methods/page/kind/)

removes `kind` frontmatter from the externally sourced file `ui_extensions.md` on [Docs](https://docs.datadoghq.com/developers/faq/ui_extensions/).

in progress docs PR: https://github.com/DataDog/documentation/pull/23956
## Changes

No visual change to the docs page should be seen.

<!-- - If there's a UI Change: please include a screenshot. -->
<!-- - If there's not a UI Change: please remove this table. -->


## Testing

<!--  Anything that would help a reviewer (or your future self) know if the change works as expected -->

## Releases

<!-- If you want to make a release at some point in the future, you'll need to add a changeset. -->
<!-- For more information, see: https://github.com/DataDog/apps/blob/master/RELEASE.md#package-releases. -->

Choose one:

-   [ ] No release is necessary.
        If you're only updating examples/documentation, this is likely what you want.
-   [ ] All packages that need a release have a changeset.
